### PR TITLE
[CBRD-26217] Revert accidental comment-only diff noise

### DIFF
--- a/src/compat/db_method_static.cpp
+++ b/src/compat/db_method_static.cpp
@@ -71,7 +71,7 @@ static void dbmeth_print (DB_OBJECT *self, DB_VALUE *result, DB_VALUE *msg);
 /*
  * qo_set_cost
  *
- * This function is exported by the optimizer query planner modules, and provides a backdoor that
+ * This function is exported by optimizer/query_planner.c, and provides a backdoor that
  * allows us some gross manipulation capabilities for the query
  * optimizer.  By adding it to the list of method implementations that
  * are statically linked we make it easy for us to add a method to an

--- a/src/optimizer/AGENTS.md
+++ b/src/optimizer/AGENTS.md
@@ -6,7 +6,7 @@ Client-side (`#if !defined(SERVER_MODE)`).
 
 | File | Role |
 |------|------|
-| `query_planner.c`, `query_planner_selectivity.c` | Core planner modules: generate and cost QO_PLAN trees from QO_ENV |
+| `query_planner.c` | Core planner: generates QO_PLAN tree from QO_ENV |
 | `query_graph.c` | Query graph construction (nodes = tables, edges = joins) |
 | `plan_generation.c` | Plan enumeration and cost-based selection |
 | `query_bitset.c` | Bitset operations for plan enumeration |
@@ -55,4 +55,4 @@ parser/ (PT_NODE tree) → optimizer/ (QO_PLAN tree) → parser/xasl_generation.
 - Optimizer runs **client-side** — statistics fetched from server, planning done locally
 - Small module but high complexity — plan enumeration is exponential in join count
 - Cost model accuracy depends on up-to-date statistics — stale stats = bad plans
-- The query planner modules handle both simple queries and complex multi-way joins
+- `query_planner.c` handles both simple queries and complex multi-way joins

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -520,7 +520,7 @@ qo_optimize_helper (QO_ENV * env)
 		}
 
 	      conj->next = next;
-	    }
+	    }			/* for (j = 0; ...) */
 	}
     }
 
@@ -2226,7 +2226,7 @@ qo_analyze_term (QO_TERM * term, int term_type)
 		    {
 		      lhs_indexable = false;
 		    }
-		  break;
+		  break;	/* give up */
 		default:
 		  lhs_indexable = false;
 		  break;

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -639,7 +639,7 @@ struct qo_term
   QO_TERMCLASS term_class;
 
   /*
-   * The rank of this term. used for the same selectivity : TODO DELETE THIS
+   * The rank of this term. used for the same selectivity
    */
   int rank;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<http://jira.cubrid.org/browse/CBRD-26217>

### Purpose

Revert unintended comment/annotation-only edits that made PR diff noisy and confusing.

### Implementation

- Restored original comment wording in `src/compat/db_method_static.cpp`.
- Reverted optimizer docs comment wording in `src/optimizer/AGENTS.md`.
- Restored two removed inline comments in `src/optimizer/query_graph.c`.
- Removed accidental `TODO DELETE THIS` note from `src/optimizer/query_graph.h`.

### Remarks

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c25c35d-617d-4ecc-800d-d1e0bbb987cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c25c35d-617d-4ecc-800d-d1e0bbb987cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

