### PR TITLE
[CBRD-26746] 히스토그램 기반 선택도/카디널리티 추정 (1/3)

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -245,6 +245,7 @@ set(OPTIMIZER_SOURCES
   ${OPTIMIZER_DIR}/query_bitset.c
   ${OPTIMIZER_DIR}/query_graph.c
   ${OPTIMIZER_DIR}/query_planner.c
+  ${OPTIMIZER_DIR}/query_planner_selectivity.c
   ${OPTIMIZER_DIR}/plan_generation.c
   )
 

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -257,6 +257,7 @@ set(OPTIMIZER_SOURCES
   ${OPTIMIZER_DIR}/query_bitset.c
   ${OPTIMIZER_DIR}/query_graph.c
   ${OPTIMIZER_DIR}/query_planner.c
+  ${OPTIMIZER_DIR}/query_planner_selectivity.c
   ${OPTIMIZER_DIR}/plan_generation.c
   )
 

--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -38,6 +38,10 @@
 #include "object_accessor.h"
 #include "authenticate.h"
 #include "query_planner.h"
+#include <cmath>
+#include <unordered_map>
+#include <unordered_set>
+
 
 static bool histogram_extract_key (const DB_VALUE *db_val, hist::histogram_key &key);
 
@@ -742,6 +746,11 @@ string_pos (const unsigned char *s, std::size_t len, std::size_t max_len = 16)
 static double
 string_domain_frac_lt (const std::string &lo, const std::string &hi, const std::string &v)
 {
+  if (v <= lo)
+    {
+      return 0.0;
+    }
+
   if (hi <= v)
     {
       return 1.0;
@@ -760,16 +769,26 @@ string_domain_frac_lt (const std::string &lo, const std::string &hi, const std::
 
   if (den <= 0.0)
     {
-      /* phi == plo: two bucket boundaries map to the same position. clamp01 is applied conservatively */
-      return clamp01 ((pv - plo));
+      return clamp01 (pv - plo);
     }
 
-  double t = (pv - plo) / den;
+  double t = clamp01 ((pv - plo) / den);
+
+  if (t > 0.0 && t < 1.0)
+    {
+      t = std::sqrt (t);
+    }
+
+  constexpr double min_interior = 0.01;
+  if (t > 0.0 && t < min_interior)
+    {
+      t = min_interior;
+    }
+
   return clamp01 (t);
 }
 
 /* histogram get selectivity functions */
-
 void
 histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success)
 {
@@ -841,7 +860,36 @@ histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *s
       return;
     }
 
-  *selectivity = (bucket_rows / total_rows) / approx_ndv;
+  *selectivity = std::max (0.5 / total_rows, (bucket_rows / total_rows) / approx_ndv);
+  *success = true;
+  return;
+}
+
+void
+histogram_get_default_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success)
+{
+  assert (selectivity != NULL);
+
+  if (rhs_db_value == NULL)
+    {
+      *success = false;
+      return;
+    }
+
+  hist::HistogramReader histogram_reader;
+  if (!histogram_init_reader_from_lhs (lhs, histogram_reader))
+    {
+      *success = false;
+      return;
+    }
+
+  if (histogram_reader.total_rows () <= 0.0)
+    {
+      *success = false;
+      return;
+    }
+
+  *selectivity = 1.0 / (static_cast<double> (histogram_reader.bucket_count ()) * 64.0);
   *success = true;
   return;
 }
@@ -1162,207 +1210,6 @@ pattern_heuristic_selectivity (const std::string &pattern, char escape_char)
     }
 
   return sel;
-}
-
-static bool
-like_match_string (const std::string &pattern, const std::string &value)
-{
-  if (pattern.empty())
-    {
-      return false;
-    }
-
-  const char *p = pattern.c_str ();
-  const char *s = value.data ();
-
-  /* most recent '%' position in pattern */
-  const char *last_percent = nullptr;
-  /* position in string that corresponds to retry after '%' */
-  const char *last_match = nullptr;
-
-  while (*s != '\0')
-    {
-      if (*p == '%')
-	{
-	  /* '%' matches any sequence, including empty */
-	  last_percent = p;
-	  ++p;
-	  last_match = s;
-	}
-      else if (*p == '_' || *p == *s)
-	{
-	  /* '_' matches any single character */
-	  ++p;
-	  ++s;
-	}
-      else if (last_percent != nullptr)
-	{
-	  /* backtrack: let previous '%' absorb one more character */
-	  p = last_percent + 1;
-	  ++last_match;
-	  s = last_match;
-	}
-      else
-	{
-	  return false;
-	}
-    }
-
-  /* trailing '%' can match empty suffix */
-  while (*p == '%')
-    {
-      ++p;
-    }
-
-  return (*p == '\0');
-}
-
-void
-histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success)
-{
-  assert (selectivity != NULL);
-
-  if (rhs_db_value == NULL)
-    {
-      *success = false;
-      return;
-    }
-
-  hist::HistogramReader histogram_reader;
-  if (!histogram_init_reader_from_lhs (lhs, histogram_reader))
-    {
-      *success = false;
-      return;
-    }
-
-  const double total_rows = histogram_reader.total_rows ();
-  if (total_rows <= 0.0)
-    {
-      *success = true;
-      *selectivity = 0.0;
-      return;
-    }
-
-  if (DB_VALUE_TYPE (rhs_db_value) != DB_TYPE_STRING
-      && DB_VALUE_TYPE (rhs_db_value) != DB_TYPE_CHAR)
-    {
-      *success = false;
-      return;
-    }
-
-  const std::string &pattern = db_get_string (rhs_db_value);
-  if (pattern.empty())
-    {
-      *success = false;
-      return;
-    }
-
-  double matched_rows = 0.0;
-  double mcv_rows = 0.0;
-
-  double matched_non_mcv_buckets = 0.0;
-  double non_mcv_buckets = 0.0;
-
-  /* Confidence that bucket_hi can represent the entire bucket. */
-  double ndv_confidence_sum = 0.0;
-
-  for (int i = 0; i < static_cast<int> (histogram_reader.bucket_count ()); i++)
-    {
-      const double bucket_rows = histogram_reader.bucket_rows (i);
-      const int approx_ndv = histogram_reader.bucket_approx_ndv (i);
-      const std::string &bucket_val = histogram_reader.bucket_hi<std::string> (i);
-
-      if (approx_ndv == 1)
-	{
-	  /* MCV bucket. */
-	  mcv_rows += bucket_rows;
-
-	  if (like_match_string (pattern, bucket_val))
-	    {
-	      matched_rows += bucket_rows;
-	    }
-
-	  continue;
-	}
-
-      /*
-       * Non-MCV bucket.
-       *
-       * Since LIKE matching is tested only against bucket_hi, the bucket
-       * becomes less reliable as approx_ndv grows.
-       */
-      non_mcv_buckets += 1.0;
-
-      const double bucket_confidence =
-	      std::min (1.0, 3.0 / static_cast<double> (approx_ndv));
-
-      ndv_confidence_sum += bucket_confidence;
-
-      if (like_match_string (pattern, bucket_val))
-	{
-	  matched_non_mcv_buckets += 1.0;
-	}
-    }
-
-  const double pattern_sel = pattern_heuristic_selectivity (pattern, '\0');
-  assert_release (pattern_sel >= 0.0 && pattern_sel <= 1.0);
-
-  double total_non_mcv_sel = pattern_sel;
-
-  if (non_mcv_buckets > 0.0)
-    {
-      const double matched_buckets_sel =
-	      matched_non_mcv_buckets / non_mcv_buckets;
-
-      /*
-       * 1. Trust the histogram more when there are more non-MCV buckets.
-       *
-       * If around 200 buckets should be considered reasonably reliable,
-       * a baseline value between 64 and 100 is usually a practical choice.
-       */
-      const double bucket_count_weight =
-	      non_mcv_buckets / (non_mcv_buckets + 64.0);
-
-      /*
-       * 2. Do not over-trust matched_buckets_sel when only a few buckets match.
-       *
-       * A single matched bucket is weak evidence. The observation becomes
-       * more meaningful once around 4 to 8 buckets match.
-       */
-      const double matched_support_weight =
-	      matched_non_mcv_buckets / (matched_non_mcv_buckets + 4.0);
-
-      /*
-       * 3. Trust bucket_hi less when each bucket contains many distinct values.
-       */
-      const double avg_ndv_confidence =
-	      ndv_confidence_sum / non_mcv_buckets;
-
-      double hist_weight =
-	      bucket_count_weight * matched_support_weight * avg_ndv_confidence;
-
-      if (hist_weight > 1.0)
-	{
-	  hist_weight = 1.0;
-	}
-      else if (hist_weight < 0.0)
-	{
-	  hist_weight = 0.0;
-	}
-
-      total_non_mcv_sel =
-	      matched_buckets_sel * hist_weight
-	      + pattern_sel * (1.0 - hist_weight);
-    }
-
-  *selectivity =
-	  (matched_rows / total_rows)
-	  + (1.0 - (mcv_rows / total_rows)) * total_non_mcv_sel;
-
-  *selectivity = std::max (1.0 / total_rows, *selectivity);
-
-  *success = true;
-  return;
 }
 
 int
@@ -1879,4 +1726,778 @@ dump_histogram (MOP classop, const char *attr_name, DB_TYPE attr_type, bool with
   db_value_clear (&null_frequency_value);
 
   return NO_ERROR;
+}
+
+/*
+ * Helper: derive histogram key kind from a PT_NODE column.
+ * This is used for eq-join when both lhs and rhs are columns.
+ */
+static bool
+histogram_extract_key_kind_from_node (PT_NODE *node, hist::histogram_key_kind &kind)
+{
+  if (node == NULL)
+    {
+      return false;
+    }
+
+  DB_TYPE type = pt_type_enum_to_db (node->type_enum);
+
+  switch (type)
+    {
+    case DB_TYPE_INTEGER:
+    case DB_TYPE_SHORT:
+    case DB_TYPE_BIGINT:
+      kind = hist::histogram_key_kind::i64;
+      return true;
+
+    case DB_TYPE_FLOAT:
+    case DB_TYPE_DOUBLE:
+    case DB_TYPE_NUMERIC:
+      kind = hist::histogram_key_kind::dbl;
+      return true;
+
+    case DB_TYPE_BIT:
+    case DB_TYPE_VARBIT:
+    case DB_TYPE_CHAR:
+    case DB_TYPE_STRING:
+      kind = hist::histogram_key_kind::str;
+      return true;
+
+    case DB_TYPE_TIME:
+    case DB_TYPE_TIMESTAMP:
+    case DB_TYPE_TIMESTAMPLTZ:
+    case DB_TYPE_DATE:
+    case DB_TYPE_TIMESTAMPTZ:
+    case DB_TYPE_DATETIME:
+    case DB_TYPE_DATETIMETZ:
+    case DB_TYPE_DATETIMELTZ:
+      kind = hist::histogram_key_kind::u64;
+      return true;
+
+    default:
+      return false;
+    }
+}
+
+/*
+ * Helper: sum approximate NDV of all non-MCV buckets.
+ * In this file, approx_ndv == 1 means an exact value bucket (MCV-like).
+ */
+static double
+histogram_sum_non_mcv_ndv (const hist::HistogramReader &reader)
+{
+  double ndv_sum = 0.0;
+
+  for (std::size_t i = 0; i < reader.bucket_count (); ++i)
+    {
+      const int approx_ndv = reader.bucket_approx_ndv (i);
+      if (approx_ndv > 1)
+	{
+	  ndv_sum += static_cast<double> (approx_ndv);
+	}
+    }
+
+  return ndv_sum;
+}
+
+/*
+ * Helper: overlap fraction for numeric ordered domains.
+ * frac1 is the overlap width divided by width(bucket1),
+ * frac2 is the overlap width divided by width(bucket2).
+ */
+static bool
+histogram_bucket_overlap_fraction_i64 (std::int64_t lo1, std::int64_t hi1,
+				       std::int64_t lo2, std::int64_t hi2,
+				       double &frac1, double &frac2)
+{
+  frac1 = 0.0;
+  frac2 = 0.0;
+
+  if (hi1 <= lo1 || hi2 <= lo2)
+    {
+      return false;
+    }
+
+  const std::int64_t overlap_lo = (lo1 < lo2) ? lo2 : lo1;
+  const std::int64_t overlap_hi = (hi1 < hi2) ? hi1 : hi2;
+
+  if (overlap_hi <= overlap_lo)
+    {
+      return false;
+    }
+
+  const long double width1 = static_cast<long double> (hi1) - static_cast<long double> (lo1);
+  const long double width2 = static_cast<long double> (hi2) - static_cast<long double> (lo2);
+  const long double overlap_width = static_cast<long double> (overlap_hi) - static_cast<long double> (overlap_lo);
+
+  if (width1 <= 0.0L || width2 <= 0.0L)
+    {
+      return false;
+    }
+
+  frac1 = clamp01 (static_cast<double> (overlap_width / width1));
+  frac2 = clamp01 (static_cast<double> (overlap_width / width2));
+  return true;
+}
+
+static bool
+histogram_bucket_overlap_fraction_u64 (std::uint64_t lo1, std::uint64_t hi1,
+				       std::uint64_t lo2, std::uint64_t hi2,
+				       double &frac1, double &frac2)
+{
+  frac1 = 0.0;
+  frac2 = 0.0;
+
+  if (hi1 <= lo1 || hi2 <= lo2)
+    {
+      return false;
+    }
+
+  const std::uint64_t overlap_lo = (lo1 < lo2) ? lo2 : lo1;
+  const std::uint64_t overlap_hi = (hi1 < hi2) ? hi1 : hi2;
+
+  if (overlap_hi <= overlap_lo)
+    {
+      return false;
+    }
+
+  const long double width1 = static_cast<long double> (hi1) - static_cast<long double> (lo1);
+  const long double width2 = static_cast<long double> (hi2) - static_cast<long double> (lo2);
+  const long double overlap_width = static_cast<long double> (overlap_hi) - static_cast<long double> (overlap_lo);
+
+  if (width1 <= 0.0L || width2 <= 0.0L)
+    {
+      return false;
+    }
+
+  frac1 = clamp01 (static_cast<double> (overlap_width / width1));
+  frac2 = clamp01 (static_cast<double> (overlap_width / width2));
+  return true;
+}
+
+static bool
+histogram_bucket_overlap_fraction_dbl (double lo1, double hi1,
+				       double lo2, double hi2,
+				       double &frac1, double &frac2)
+{
+  frac1 = 0.0;
+  frac2 = 0.0;
+
+  if (hi1 <= lo1 || hi2 <= lo2)
+    {
+      return false;
+    }
+
+  const double overlap_lo = (lo1 < lo2) ? lo2 : lo1;
+  const double overlap_hi = (hi1 < hi2) ? hi1 : hi2;
+
+  if (overlap_hi <= overlap_lo)
+    {
+      return false;
+    }
+
+  const long double width1 = static_cast<long double> (hi1) - static_cast<long double> (lo1);
+  const long double width2 = static_cast<long double> (hi2) - static_cast<long double> (lo2);
+  const long double overlap_width = static_cast<long double> (overlap_hi) - static_cast<long double> (overlap_lo);
+
+  if (width1 <= 0.0L || width2 <= 0.0L)
+    {
+      return false;
+    }
+
+  frac1 = clamp01 (static_cast<double> (overlap_width / width1));
+  frac2 = clamp01 (static_cast<double> (overlap_width / width2));
+  return true;
+}
+
+/*
+ * String overlap fraction uses the existing string_domain_frac_lt() mapping.
+ * This is only a heuristic, but it is still useful as weak overlap evidence.
+ */
+static bool
+histogram_bucket_overlap_fraction_str (const std::string &lo1, const std::string &hi1,
+				       const std::string &lo2, const std::string &hi2,
+				       double &frac1, double &frac2)
+{
+  frac1 = 0.0;
+  frac2 = 0.0;
+
+  if (hi1 <= lo1 || hi2 <= lo2)
+    {
+      return false;
+    }
+
+  const std::string overlap_lo = (lo1 < lo2) ? lo2 : lo1;
+  const std::string overlap_hi = (hi1 < hi2) ? hi1 : hi2;
+
+  if (overlap_hi <= overlap_lo)
+    {
+      return false;
+    }
+
+  frac1 = clamp01 (string_domain_frac_lt (lo1, hi1, overlap_hi)
+		   - string_domain_frac_lt (lo1, hi1, overlap_lo));
+  frac2 = clamp01 (string_domain_frac_lt (lo2, hi2, overlap_hi)
+		   - string_domain_frac_lt (lo2, hi2, overlap_lo));
+
+  return (frac1 > 0.0 || frac2 > 0.0);
+}
+/*
+ * Stage 2:
+ * Match exact-value buckets (approx_ndv == 1) across lhs and rhs.
+ *
+ * This is the highest-confidence component of eq-join estimation.  Keep
+ * matched and unmatched MCV frequencies separately so the caller can account
+ * for the remaining population in the same spirit as PostgreSQL's
+ * eqjoinsel_inner().
+ *
+ * Implementation note:
+ * Use a hash table for rhs exact buckets to avoid O(lhs_bucket_count * rhs_bucket_count)
+ * pair comparison. This also makes repeated join selectivity estimation less expensive.
+ */
+template <typename T>
+static double
+histogram_eqjoin_exact_mcv_mass_t (const hist::HistogramReader &lhs_reader,
+				   const hist::HistogramReader &rhs_reader,
+				   double lhs_total_rows, double rhs_total_rows,
+				   double &lhs_mcv_rows, double &rhs_mcv_rows,
+				   double &lhs_matched_mcv_frac, double &rhs_matched_mcv_frac,
+				   double &lhs_unmatched_mcv_frac, double &rhs_unmatched_mcv_frac,
+				   int &matched_mcv_count, int &lhs_mcv_count, int &rhs_mcv_count)
+{
+  lhs_mcv_rows = 0.0;
+  rhs_mcv_rows = 0.0;
+  lhs_matched_mcv_frac = 0.0;
+  rhs_matched_mcv_frac = 0.0;
+  lhs_unmatched_mcv_frac = 0.0;
+  rhs_unmatched_mcv_frac = 0.0;
+  matched_mcv_count = 0;
+  lhs_mcv_count = 0;
+  rhs_mcv_count = 0;
+
+  if (lhs_total_rows <= 0.0 || rhs_total_rows <= 0.0)
+    {
+      return 0.0;
+    }
+
+  std::unordered_map<T, double> rhs_prob_by_value;
+  std::unordered_set<T> matched_rhs_values;
+
+  for (std::size_t j = 0; j < rhs_reader.bucket_count (); ++j)
+    {
+      if (rhs_reader.bucket_approx_ndv (j) != 1)
+	{
+	  continue;
+	}
+
+      const double rhs_rows = static_cast<double> (rhs_reader.bucket_rows (j));
+      if (rhs_rows <= 0.0)
+	{
+	  continue;
+	}
+
+      rhs_mcv_rows += rhs_rows;
+      rhs_mcv_count++;
+
+      const T &rhs_val = rhs_reader.bucket_hi<T> (j);
+      rhs_prob_by_value[rhs_val] += rhs_rows / rhs_total_rows;
+    }
+
+  double exact_mass = 0.0;
+
+  for (std::size_t i = 0; i < lhs_reader.bucket_count (); ++i)
+    {
+      if (lhs_reader.bucket_approx_ndv (i) != 1)
+	{
+	  continue;
+	}
+
+      const double lhs_rows = static_cast<double> (lhs_reader.bucket_rows (i));
+      if (lhs_rows <= 0.0)
+	{
+	  continue;
+	}
+
+      lhs_mcv_rows += lhs_rows;
+      lhs_mcv_count++;
+
+      const T &lhs_val = lhs_reader.bucket_hi<T> (i);
+      typename std::unordered_map<T, double>::const_iterator it = rhs_prob_by_value.find (lhs_val);
+      if (it != rhs_prob_by_value.end ())
+	{
+	  const double lhs_prob = lhs_rows / lhs_total_rows;
+	  exact_mass += lhs_prob * it->second;
+	  lhs_matched_mcv_frac += lhs_prob;
+	  matched_rhs_values.insert (lhs_val);
+	  matched_mcv_count++;
+	}
+    }
+
+  for (typename std::unordered_set<T>::const_iterator it = matched_rhs_values.begin ();
+       it != matched_rhs_values.end (); ++it)
+    {
+      typename std::unordered_map<T, double>::const_iterator rhs_it = rhs_prob_by_value.find (*it);
+      if (rhs_it != rhs_prob_by_value.end ())
+	{
+	  rhs_matched_mcv_frac += rhs_it->second;
+	}
+    }
+
+  lhs_unmatched_mcv_frac = clamp01 ((lhs_mcv_rows / lhs_total_rows) - lhs_matched_mcv_frac);
+  rhs_unmatched_mcv_frac = clamp01 ((rhs_mcv_rows / rhs_total_rows) - rhs_matched_mcv_frac);
+
+  return clamp01 (exact_mass);
+}
+
+/*
+ * Stage 3b:
+ * Refine residual non-MCV overlap by scanning bucket pairs and using bucket
+ * overlap as weak evidence of common value-domain coverage.
+ *
+ * Only non-MCV buckets (approx_ndv > 1) are considered here.
+ * For each overlapping bucket pair:
+ *
+ *   local_mass = lhs_overlap_prob * rhs_overlap_prob / max(lhs_overlap_ndv, rhs_overlap_ndv)
+ *
+ * This keeps the estimate conservative while still letting histograms influence
+ * join cardinality beyond simple NDV fallback.
+ */
+template <typename T, typename OverlapFunc>
+static double
+histogram_eqjoin_residual_overlap_mass_t (const hist::HistogramReader &lhs_reader,
+    const hist::HistogramReader &rhs_reader,
+    double lhs_total_rows, double rhs_total_rows,
+    OverlapFunc overlap_func)
+{
+  double residual_mass = 0.0;
+
+  /*
+   * We require i >= 1 and j >= 1 because a non-MCV bucket needs a lower
+   * boundary from the previous bucket's endpoint.
+   */
+  for (std::size_t i = 1; i < lhs_reader.bucket_count (); ++i)
+    {
+      const int lhs_ndv_i = lhs_reader.bucket_approx_ndv (i);
+      if (lhs_ndv_i <= 1)
+	{
+	  continue;
+	}
+
+      const double lhs_bucket_rows = static_cast<double> (lhs_reader.bucket_rows (i));
+      if (lhs_bucket_rows <= 0.0)
+	{
+	  continue;
+	}
+
+      const T &lhs_lo = lhs_reader.bucket_hi<T> (i - 1);
+      const T &lhs_hi = lhs_reader.bucket_hi<T> (i);
+
+      for (std::size_t j = 1; j < rhs_reader.bucket_count (); ++j)
+	{
+	  const int rhs_ndv_j = rhs_reader.bucket_approx_ndv (j);
+	  if (rhs_ndv_j <= 1)
+	    {
+	      continue;
+	    }
+
+	  const double rhs_bucket_rows = static_cast<double> (rhs_reader.bucket_rows (j));
+	  if (rhs_bucket_rows <= 0.0)
+	    {
+	      continue;
+	    }
+
+	  const T &rhs_lo = rhs_reader.bucket_hi<T> (j - 1);
+	  const T &rhs_hi = rhs_reader.bucket_hi<T> (j);
+
+	  double lhs_overlap_frac = 0.0;
+	  double rhs_overlap_frac = 0.0;
+
+	  if (!overlap_func (lhs_lo, lhs_hi, rhs_lo, rhs_hi, lhs_overlap_frac, rhs_overlap_frac))
+	    {
+	      continue;
+	    }
+
+	  if (lhs_overlap_frac <= 0.0 || rhs_overlap_frac <= 0.0)
+	    {
+	      continue;
+	    }
+
+	  double lhs_overlap_ndv = static_cast<double> (lhs_ndv_i) * lhs_overlap_frac;
+	  double rhs_overlap_ndv = static_cast<double> (rhs_ndv_j) * rhs_overlap_frac;
+
+	  if (lhs_overlap_ndv < 1.0)
+	    {
+	      lhs_overlap_ndv = 1.0;
+	    }
+	  if (rhs_overlap_ndv < 1.0)
+	    {
+	      rhs_overlap_ndv = 1.0;
+	    }
+
+	  const double lhs_overlap_prob = (lhs_bucket_rows / lhs_total_rows) * lhs_overlap_frac;
+	  const double rhs_overlap_prob = (rhs_bucket_rows / rhs_total_rows) * rhs_overlap_frac;
+
+	  const double local_join_sel = 1.0 / ((lhs_overlap_ndv > rhs_overlap_ndv) ? lhs_overlap_ndv : rhs_overlap_ndv);
+
+	  residual_mass += lhs_overlap_prob * rhs_overlap_prob * local_join_sel;
+	}
+    }
+
+  return clamp01 (residual_mass);
+}
+
+/*
+ * Stage 3a:
+ * Conservative residual fallback using non-MCV NDV only.
+ */
+static double
+histogram_eqjoin_residual_fallback_mass (const hist::HistogramReader &lhs_reader,
+    const hist::HistogramReader &rhs_reader,
+    double lhs_non_mcv_frac, double rhs_non_mcv_frac)
+{
+  const double lhs_residual_ndv = histogram_sum_non_mcv_ndv (lhs_reader);
+  const double rhs_residual_ndv = histogram_sum_non_mcv_ndv (rhs_reader);
+
+  if (lhs_residual_ndv <= 0.0 || rhs_residual_ndv <= 0.0)
+    {
+      return 0.0;
+    }
+
+  const double residual_sel = 1.0 / ((lhs_residual_ndv > rhs_residual_ndv)
+				     ? lhs_residual_ndv : rhs_residual_ndv);
+
+  return clamp01 (lhs_non_mcv_frac * rhs_non_mcv_frac * residual_sel);
+}
+
+/*
+ * PostgreSQL-style residual estimate for the part not covered by exact MCV
+ * matches.  This accounts for unmatched MCVs against the opposite non-MCV
+ * population, plus non-MCV values against unmatched MCVs/non-MCV values.
+ */
+static double
+histogram_eqjoin_pg_mcv_residual_mass (double exact_mcv_mass,
+				       double lhs_unmatched_mcv_frac, double rhs_unmatched_mcv_frac,
+				       double lhs_other_frac, double rhs_other_frac,
+				       double lhs_total_ndv, double rhs_total_ndv,
+				       int lhs_mcv_count, int rhs_mcv_count, int matched_mcv_count)
+{
+  double lhs_view = exact_mcv_mass;
+  double rhs_view = exact_mcv_mass;
+  double rhs_unmatched_denom;
+  double lhs_unmatched_denom;
+  double rhs_remaining_denom;
+  double lhs_remaining_denom;
+
+  lhs_other_frac = clamp01 (lhs_other_frac);
+  rhs_other_frac = clamp01 (rhs_other_frac);
+  lhs_unmatched_mcv_frac = clamp01 (lhs_unmatched_mcv_frac);
+  rhs_unmatched_mcv_frac = clamp01 (rhs_unmatched_mcv_frac);
+
+  rhs_unmatched_denom = rhs_total_ndv - (double) rhs_mcv_count;
+  if (rhs_unmatched_denom > 0.0)
+    {
+      lhs_view += lhs_unmatched_mcv_frac * rhs_other_frac / rhs_unmatched_denom;
+    }
+
+  rhs_remaining_denom = rhs_total_ndv - (double) matched_mcv_count;
+  if (rhs_remaining_denom > 0.0)
+    {
+      lhs_view += lhs_other_frac * (rhs_other_frac + rhs_unmatched_mcv_frac) / rhs_remaining_denom;
+    }
+
+  lhs_unmatched_denom = lhs_total_ndv - (double) lhs_mcv_count;
+  if (lhs_unmatched_denom > 0.0)
+    {
+      rhs_view += rhs_unmatched_mcv_frac * lhs_other_frac / lhs_unmatched_denom;
+    }
+
+  lhs_remaining_denom = lhs_total_ndv - (double) matched_mcv_count;
+  if (lhs_remaining_denom > 0.0)
+    {
+      rhs_view += rhs_other_frac * (lhs_other_frac + lhs_unmatched_mcv_frac) / lhs_remaining_denom;
+    }
+
+  return clamp01 ((lhs_view < rhs_view) ? lhs_view : rhs_view);
+}
+
+/*
+ * histogram_get_eqjoin_selectivity () - Estimate equality join selectivity
+ *                                       when both lhs and rhs are columns.
+ *
+ * This function implements the 3-stage design:
+ *
+ *   Stage 1. Establish a safe baseline using residual NDV logic.
+ *   Stage 2. Add exact mass from exact-value buckets (MCV buckets).
+ *   Stage 3. Estimate the remaining non-MCV overlap, preferably with
+ *            bucket overlap refinement, and fall back to residual NDV
+ *            when no overlap signal is available.
+ */
+void
+histogram_get_eqjoin_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity, bool *success)
+{
+  assert (selectivity != NULL);
+  assert (success != NULL);
+
+  *selectivity = 0.0;
+  *success = false;
+
+  if (lhs == NULL || rhs == NULL)
+    {
+      return;
+    }
+
+  hist::HistogramReader lhs_reader;
+  hist::HistogramReader rhs_reader;
+
+  if (!histogram_init_reader_from_lhs (lhs, lhs_reader)
+      || !histogram_init_reader_from_lhs (rhs, rhs_reader))
+    {
+      return;
+    }
+
+  hist::histogram_key_kind lhs_kind = hist::histogram_key_kind::invalid;
+  hist::histogram_key_kind rhs_kind = hist::histogram_key_kind::invalid;
+
+  if (!histogram_extract_key_kind_from_node (lhs, lhs_kind)
+      || !histogram_extract_key_kind_from_node (rhs, rhs_kind))
+    {
+      return;
+    }
+
+  /*
+   * For now, require both sides to share the same histogram domain kind.
+   * Mixed numeric kinds (e.g. i64 vs dbl) can be added later if needed.
+   */
+  if (lhs_kind != rhs_kind)
+    {
+      return;
+    }
+
+  const double lhs_total_rows = static_cast<double> (lhs_reader.total_rows ());
+  const double rhs_total_rows = static_cast<double> (rhs_reader.total_rows ());
+
+  if (lhs_total_rows <= 0.0 || rhs_total_rows <= 0.0)
+    {
+      *selectivity = 0.0;
+      *success = true;
+      return;
+    }
+
+  double lhs_mcv_rows = 0.0;
+  double rhs_mcv_rows = 0.0;
+  double exact_mcv_mass = 0.0;
+  double overlap_residual_mass = 0.0;
+  double lhs_matched_mcv_frac = 0.0;
+  double rhs_matched_mcv_frac = 0.0;
+  double lhs_unmatched_mcv_frac = 0.0;
+  double rhs_unmatched_mcv_frac = 0.0;
+  int matched_mcv_count = 0;
+  int lhs_mcv_count = 0;
+  int rhs_mcv_count = 0;
+
+  switch (lhs_kind)
+    {
+    case hist::histogram_key_kind::i64:
+      exact_mcv_mass =
+	      histogram_eqjoin_exact_mcv_mass_t<std::int64_t> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  lhs_mcv_rows, rhs_mcv_rows,
+		  lhs_matched_mcv_frac, rhs_matched_mcv_frac,
+		  lhs_unmatched_mcv_frac, rhs_unmatched_mcv_frac,
+		  matched_mcv_count, lhs_mcv_count, rhs_mcv_count);
+
+      overlap_residual_mass =
+	      histogram_eqjoin_residual_overlap_mass_t<std::int64_t> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  histogram_bucket_overlap_fraction_i64);
+      break;
+
+    case hist::histogram_key_kind::dbl:
+      exact_mcv_mass =
+	      histogram_eqjoin_exact_mcv_mass_t<double> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  lhs_mcv_rows, rhs_mcv_rows,
+		  lhs_matched_mcv_frac, rhs_matched_mcv_frac,
+		  lhs_unmatched_mcv_frac, rhs_unmatched_mcv_frac,
+		  matched_mcv_count, lhs_mcv_count, rhs_mcv_count);
+
+      overlap_residual_mass =
+	      histogram_eqjoin_residual_overlap_mass_t<double> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  histogram_bucket_overlap_fraction_dbl);
+      break;
+
+    case hist::histogram_key_kind::str:
+      exact_mcv_mass =
+	      histogram_eqjoin_exact_mcv_mass_t<std::string> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  lhs_mcv_rows, rhs_mcv_rows,
+		  lhs_matched_mcv_frac, rhs_matched_mcv_frac,
+		  lhs_unmatched_mcv_frac, rhs_unmatched_mcv_frac,
+		  matched_mcv_count, lhs_mcv_count, rhs_mcv_count);
+
+      overlap_residual_mass =
+	      histogram_eqjoin_residual_overlap_mass_t<std::string> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  histogram_bucket_overlap_fraction_str);
+      break;
+
+    case hist::histogram_key_kind::u64:
+      exact_mcv_mass =
+	      histogram_eqjoin_exact_mcv_mass_t<std::uint64_t> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  lhs_mcv_rows, rhs_mcv_rows,
+		  lhs_matched_mcv_frac, rhs_matched_mcv_frac,
+		  lhs_unmatched_mcv_frac, rhs_unmatched_mcv_frac,
+		  matched_mcv_count, lhs_mcv_count, rhs_mcv_count);
+
+      overlap_residual_mass =
+	      histogram_eqjoin_residual_overlap_mass_t<std::uint64_t> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  histogram_bucket_overlap_fraction_u64);
+      break;
+
+    case hist::histogram_key_kind::invalid:
+    default:
+      return;
+    }
+
+  /*
+   * Stage 1 baseline:
+   * Derive the residual non-MCV mass cap from remaining row fractions,
+   * then compute the NDV-based fallback for that region.
+   */
+  double lhs_non_mcv_frac = (lhs_total_rows - lhs_mcv_rows) / lhs_total_rows;
+  double rhs_non_mcv_frac = (rhs_total_rows - rhs_mcv_rows) / rhs_total_rows;
+
+  lhs_non_mcv_frac = clamp01 (lhs_non_mcv_frac);
+  rhs_non_mcv_frac = clamp01 (rhs_non_mcv_frac);
+
+  const double lhs_total_ndv = histogram_sum_non_mcv_ndv (lhs_reader) + (double) lhs_mcv_count;
+  const double rhs_total_ndv = histogram_sum_non_mcv_ndv (rhs_reader) + (double) rhs_mcv_count;
+  const double fallback_residual_mass =
+	  histogram_eqjoin_residual_fallback_mass (lhs_reader, rhs_reader,
+	      lhs_non_mcv_frac, rhs_non_mcv_frac);
+  const double pg_mcv_mass =
+	  histogram_eqjoin_pg_mcv_residual_mass (exact_mcv_mass,
+	      lhs_unmatched_mcv_frac, rhs_unmatched_mcv_frac,
+	      lhs_non_mcv_frac, rhs_non_mcv_frac,
+	      lhs_total_ndv, rhs_total_ndv,
+	      lhs_mcv_count, rhs_mcv_count, matched_mcv_count);
+
+  /*
+   * Stage 3 final residual choice:
+   *
+   * Start from the PG-style MCV/non-MCV decomposition when MCVs are available.
+   * If MCV decomposition is unavailable, use the global non-MCV NDV fallback.
+   * Bucket overlap is only a reducing signal. It must not increase residual
+   * equality join selectivity above the chosen statistical baseline.
+   *
+   * This is important for join ordering because range overlap between histogram
+   * buckets is weak evidence. If we let overlap_residual_mass replace the
+   * fallback whenever it is positive, common id-like domains can make joins look
+   * much less selective than they should be.
+   */
+  const bool has_both_mcv_lists = (lhs_mcv_count > 0 && rhs_mcv_count > 0);
+  double selectivity_mass = has_both_mcv_lists ? pg_mcv_mass : exact_mcv_mass + fallback_residual_mass;
+
+  if (!has_both_mcv_lists && overlap_residual_mass > 0.0)
+    {
+      double overlap_mass = exact_mcv_mass + overlap_residual_mass;
+
+      if (overlap_mass < selectivity_mass)
+	{
+	  selectivity_mass = overlap_mass;
+	}
+    }
+
+  /*
+   * Final join selectivity:
+   *
+   *   exact MCV contribution
+   * + matched/unmatched MCV and non-MCV contribution
+   */
+  *selectivity = clamp01 (selectivity_mass);
+
+  const double lhs_non_null_frac = clamp01 (1.0 - lhs->info.name.null_frequency);
+  const double rhs_non_null_frac = clamp01 (1.0 - rhs->info.name.null_frequency);
+
+  *selectivity = clamp01 (*selectivity * lhs_non_null_frac * rhs_non_null_frac);
+
+  *success = true;
+}
+
+/*
+ * histogram_get_max_mcv_frequency () - get the largest single MCV frequency
+ *
+ * max_mcv_frequency = max(rows of one bucket whose approx_ndv == 1) / total histogram rows
+ *
+ * In this histogram format, approx_ndv == 1 means exact-value bucket,
+ * which is treated as an MCV bucket.
+ */
+void
+histogram_get_max_mcv_frequency (PT_NODE *pt_col, double *out_max_mcv_frequency, bool *out_success)
+{
+  hist::HistogramReader reader;
+  double total_rows = 0.0;
+  double max_mcv_rows = 0.0;
+
+  if (out_max_mcv_frequency != NULL)
+    {
+      *out_max_mcv_frequency = 0.0;
+    }
+
+  if (out_success != NULL)
+    {
+      *out_success = false;
+    }
+
+  if (pt_col == NULL || out_max_mcv_frequency == NULL || out_success == NULL)
+    {
+      return;
+    }
+
+  if (!histogram_init_reader_from_lhs (pt_col, reader))
+    {
+      return;
+    }
+
+  total_rows = static_cast<double> (reader.total_rows ());
+  if (total_rows <= 0.0)
+    {
+      return;
+    }
+
+  for (std::size_t i = 0; i < reader.bucket_count (); i++)
+    {
+      const int approx_ndv = reader.bucket_approx_ndv (i);
+
+      if (approx_ndv != 1)
+	{
+	  continue;
+	}
+
+      const double bucket_rows = static_cast<double> (reader.bucket_rows (i));
+      if (bucket_rows <= 0.0)
+	{
+	  continue;
+	}
+
+      if (bucket_rows > max_mcv_rows)
+	{
+	  max_mcv_rows = bucket_rows;
+	}
+    }
+
+  if (max_mcv_rows < 0.0)
+    {
+      max_mcv_rows = 0.0;
+    }
+  else if (max_mcv_rows > total_rows)
+    {
+      max_mcv_rows = total_rows;
+    }
+
+  *out_max_mcv_frequency = clamp01 (max_mcv_rows / total_rows);
+  *out_success = true;
 }

--- a/src/optimizer/histogram/histogram_cl.hpp
+++ b/src/optimizer/histogram/histogram_cl.hpp
@@ -291,7 +291,9 @@ void histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, doub
 void histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool is_ge, bool include_equal,
 				     double *selectivity,
 				     bool *success);
-void histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success);
+void histogram_get_default_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success);
+void histogram_get_eqjoin_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity, bool *success);
+void histogram_get_max_mcv_frequency (PT_NODE *pt_col, double *out_max_mcv_frequency, bool *out_success);
 /* histogram utility functions */
 int db_get_histogram (MOP classop, const char *attr_name, DB_OBJECT **histogram_obj);
 bool is_histogrammable_type (DB_TYPE type);

--- a/src/optimizer/plan_generation.c
+++ b/src/optimizer/plan_generation.c
@@ -38,6 +38,7 @@
 #include "xasl.h"
 #include "xasl_generation.h"
 #include "xasl_predicate.hpp"
+#include <cmath>
 
 typedef int (*ELIGIBILITY_FN) (QO_TERM *);
 
@@ -1409,6 +1410,44 @@ is_always_true (QO_TERM * term)
   return true;
 }
 
+static double
+qo_pred_rank_weight (int rank)
+{
+  switch (rank)
+    {
+    case 0:
+    case 1:
+      return 1.0;
+
+    case 2:
+      return 1.5;
+
+    case 3:
+      return 8.0;
+
+    default:
+      return 12.0;
+    }
+}
+
+static double
+qo_pred_eval_score (double sel, int rank)
+{
+  double weight;
+
+  if (sel <= 0.0)
+    {
+      sel = 1e-12;
+    }
+  else if (sel > 1.0)
+    {
+      sel = 1.0;
+    }
+
+  weight = qo_pred_rank_weight (rank);
+  return -std::log (sel) / weight;
+}
+
 /*
  * make_pred_from_bitset () -
  *   return: PT_NODE *
@@ -1437,6 +1476,8 @@ make_pred_from_bitset (QO_ENV * env, BITSET * predset, ELIGIBILITY_FN safe)
   pred_list = NULL;		/* init */
   for (i = bitset_iterate (predset, &bi); i != -1; i = bitset_next_member (&bi))
     {
+      double pointer_score;
+
       term = QO_ENV_TERM (env, i);
 
       /* Don't ever let one of our fabricated terms find its way into the predicate; that will cause serious confusion. */
@@ -1459,21 +1500,37 @@ make_pred_from_bitset (QO_ENV * env, BITSET * predset, ELIGIBILITY_FN safe)
 	  goto exit_on_error;
 	}
 
-      /* set AND predicate evaluation pred_order desc, selectivity asc, rank asc */
+      /* keep original metadata for downstream use/debug */
       pointer->info.pointer.sel = QO_TERM_SELECTIVITY (term);
       pointer->info.pointer.rank = QO_TERM_RANK (term);
       pointer->info.pointer.pred_order = QO_TERM_PRED_ORDER (term);
 
-      /* insert to the AND predicate list by descending order of (selectivity, rank) vector; this order is used at
-       * pt_to_pred_expr_with_arg() */
+      pointer_score = qo_pred_eval_score (pointer->info.pointer.sel, pointer->info.pointer.rank);
+
+      /*
+       * insert to the AND predicate list on:
+       *   1) pred_order desc
+       *   2) effective score desc
+       *   3) selectivity asc
+       *   4) rank asc
+       */
       found = false;		/* init */
       prev = NULL;		/* init */
       for (curr = pred_list; curr; curr = curr->next)
 	{
+	  double curr_score;
+
+	  curr_score = qo_pred_eval_score (curr->info.pointer.sel, curr->info.pointer.rank);
+
 	  cmp = pointer->info.pointer.pred_order - curr->info.pointer.pred_order;
 
 	  if (cmp == 0)
-	    {			/* same selectivity, re-compare rank */
+	    {
+	      cmp = pointer_score - curr_score;
+	    }
+
+	  if (cmp == 0)
+	    {
 	      cmp = curr->info.pointer.sel - pointer->info.pointer.sel;
 	    }
 

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -43,6 +43,7 @@
 #include "optimizer.h"
 #include "query_graph.h"
 #include "query_planner.h"
+#include "histogram_cl.hpp"
 #include "schema_manager.h"
 #include "statistics.h"
 #include "system_parameter.h"
@@ -1766,6 +1767,8 @@ qo_add_term (PT_NODE * conjunct, int term_type, QO_ENV * env)
   QO_TERM_MULTI_COL_SEGS (term) = NULL;	/* init */
   QO_TERM_MULTI_COL_CNT (term) = 0;	/* init */
   QO_TERM_PRED_ORDER (term) = pt_is_expr_node (conjunct) ? conjunct->info.expr.pred_order : 0;
+  QO_TERM_HEAD_MCV_MAX_FREQUENCY (term) = 0.0;
+  QO_TERM_TAIL_MCV_MAX_FREQUENCY (term) = 0.0;
 
   env->nterms++;
 
@@ -2788,6 +2791,35 @@ wrapup:
 
     case PREDICATE_TERM:
       QO_TERM_SELECTIVITY (term) = qo_expr_selectivity (env, pt_expr);
+
+      if (qo_is_equi_join_term (term))
+	{
+	  double lhs_mcv_max_frequency = 0.0;
+	  double rhs_mcv_max_frequency = 0.0;
+	  bool success1 = false;
+	  bool success2 = false;
+	  histogram_get_max_mcv_frequency (pt_expr->info.expr.arg1, &lhs_mcv_max_frequency, &success1);
+	  histogram_get_max_mcv_frequency (pt_expr->info.expr.arg2, &rhs_mcv_max_frequency, &success2);
+	  if (success1 || success2)
+	    {
+	      if (head_node != NULL && BITSET_MEMBER (lhs_nodes, QO_NODE_IDX (head_node)))
+		{
+		  QO_TERM_HEAD_MCV_MAX_FREQUENCY (term) = success1 ? lhs_mcv_max_frequency : 0.0;
+		  QO_TERM_TAIL_MCV_MAX_FREQUENCY (term) = success2 ? rhs_mcv_max_frequency : 0.0;
+		}
+	      else
+		{
+		  QO_TERM_HEAD_MCV_MAX_FREQUENCY (term) = success2 ? rhs_mcv_max_frequency : 0.0;
+		  QO_TERM_TAIL_MCV_MAX_FREQUENCY (term) = success1 ? lhs_mcv_max_frequency : 0.0;
+		}
+	    }
+	  else
+	    {
+	      QO_TERM_HEAD_MCV_MAX_FREQUENCY (term) = 0.0;
+	      QO_TERM_TAIL_MCV_MAX_FREQUENCY (term) = 0.0;
+	    }
+	}
+
       break;
 
     default:
@@ -6088,6 +6120,8 @@ qo_exchange (QO_TERM * t0, QO_TERM * t1)
   BITSET_EXCHANGE (t0->nodes, t1->nodes);
   BITSET_EXCHANGE (t0->segments, t1->segments);
   DOUBLE_EXCHANGE (t0->selectivity, t1->selectivity);
+  DOUBLE_EXCHANGE (t0->head_mcv_max_frequency, t1->head_mcv_max_frequency);
+  DOUBLE_EXCHANGE (t0->tail_mcv_max_frequency, t1->tail_mcv_max_frequency);
   INT_EXCHANGE (t0->rank, t1->rank);
   PT_NODE_EXCHANGE (t0->pt_expr, t1->pt_expr);
   INT_EXCHANGE (t0->location, t1->location);
@@ -6109,6 +6143,119 @@ qo_exchange (QO_TERM * t0, QO_TERM * t1)
   /*
    * DON'T exchange the 'idx' values!
    */
+}
+
+static double
+qo_rank_weight (int rank)
+{
+  switch (rank)
+    {
+    case 0:
+    case 1:
+      return 1.0;
+
+    case 2:
+      return 1.5;
+
+    case 3:
+      return 8.0;
+
+    default:
+      return 12.0;
+    }
+}
+
+static double
+qo_term_eval_weight (QO_TERM * term)
+{
+  PT_NODE *expr;
+  PT_NODE *lhs;
+  PT_NODE *rhs;
+
+  if (term == NULL)
+    {
+      return 1.0;
+    }
+
+  expr = QO_TERM_PT_EXPR (term);
+  if (expr == NULL || expr->node_type != PT_EXPR)
+    {
+      return 1.0;
+    }
+
+  lhs = expr->info.expr.arg1;
+  rhs = expr->info.expr.arg2;
+
+  switch (expr->info.expr.op)
+    {
+    case PT_EQ:
+    case PT_NE:
+    case PT_NULLSAFE_EQ:
+      if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	{
+	  return 1.1;
+	}
+      return 1.0;
+
+    case PT_LT:
+    case PT_LE:
+    case PT_GT:
+    case PT_GE:
+    case PT_BETWEEN:
+    case PT_RANGE:
+      if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	{
+	  return 1.25;
+	}
+      return 1.0;
+
+    case PT_LIKE:
+      if (rhs != NULL && rhs->node_type == PT_VALUE)
+	{
+	  const char *pat = db_get_string (&rhs->info.value.db_value);
+	  if (pat != NULL)
+	    {
+	      const char *pct = strchr (pat, '%');
+	      const char *und = strchr (pat, '_');
+
+	      if (pct != NULL && pct[1] == '\0' && und == NULL && pct != pat)
+		{
+		  return 1.25;	/* prefix like 'abc%' */
+		}
+
+	      if (pat[0] == '%' || und != NULL)
+		{
+		  return 2.5;	/* contains/complex pattern */
+		}
+	    }
+	}
+      return 1.5;
+
+    default:
+      return 1.0;
+    }
+}
+
+static double
+qo_term_eval_score (QO_TERM * term)
+{
+  double sel;
+  double weight;
+
+  sel = QO_TERM_SELECTIVITY (term);
+
+  if (sel <= 0.0)
+    {
+      sel = 1e-12;
+    }
+  else if (sel > 1.0)
+    {
+      sel = 1.0;
+    }
+
+  weight = qo_term_eval_weight (term);
+
+  return (1.0 - sel) / weight;
 }
 
 /*
@@ -6169,25 +6316,68 @@ qo_discover_edges (QO_ENV * env)
 	  if (QO_TERM_SELECTIVITY (term1) < QO_TERM_SELECTIVITY (term2))
 	    {
 	      qo_exchange (term1, term2);
+	      term1 = QO_ENV_TERM (env, t1);
 	    }
 	}
     }
-  /* sort sarg-term on pred_order desc, selectivity asc */
+
+  /*
+   * IMPORTANT:
+   * get_rank() is normally called after qo_discover_edges() in qo_optimize_helper().
+   * If we want to use rank here for sarg-term ordering, compute it here explicitly.
+   */
+  for (t1 = i; t1 < env->nterms; t1++)
+    {
+      get_term_rank (env, QO_ENV_TERM (env, t1));
+    }
+
+  /*
+   * sort sarg-term on:
+   *   1) pred_order desc
+   *   2) effective score desc
+   *      effective score = -log(selectivity) / rank_weight
+   *   3) selectivity asc
+   *   4) rank asc
+   */
   for (t1 = i; t1 < env->nterms - 1; t1++)
     {
       term1 = QO_ENV_TERM (env, t1);
+
       for (t2 = t1 + 1; t2 < env->nterms; t2++)
 	{
+	  double score1, score2;
+
 	  term2 = QO_ENV_TERM (env, t2);
 
 	  if (QO_TERM_PRED_ORDER (term1) < QO_TERM_PRED_ORDER (term2))
 	    {
 	      qo_exchange (term1, term2);
+	      term1 = QO_ENV_TERM (env, t1);
 	    }
-	  else if ((QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2))
-		   && (QO_TERM_SELECTIVITY (term1) > QO_TERM_SELECTIVITY (term2)))
+	  else if (QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2))
 	    {
-	      qo_exchange (term1, term2);
+	      score1 = qo_term_eval_score (term1);
+	      score2 = qo_term_eval_score (term2);
+
+	      if (score1 < score2)
+		{
+		  qo_exchange (term1, term2);
+		  term1 = QO_ENV_TERM (env, t1);
+		}
+	      else if (fabs (score1 - score2) <= 1e-12)
+		{
+		  if (QO_TERM_SELECTIVITY (term1) > QO_TERM_SELECTIVITY (term2))
+		    {
+		      qo_exchange (term1, term2);
+		      term1 = QO_ENV_TERM (env, t1);
+		    }
+		  else if (QO_TERM_SELECTIVITY (term1) == QO_TERM_SELECTIVITY (term2)
+			   && QO_TERM_RANK (term1) > QO_TERM_RANK (term2))
+		    {
+		      qo_exchange (term1, term2);
+		      term1 = QO_ENV_TERM (env, t1);
+		    }
+		}
 	    }
 	}
     }
@@ -6240,7 +6430,7 @@ qo_discover_edges (QO_ENV * env)
 		{
 		  bitset_union (&direct_nodes, &(QO_TERM_NODES (edge2)));
 		}
-	    }			/* for (j = 0; ...) */
+	    }
 
 	  /* check for direct connected nodes */
 	  for (t = bitset_iterate (&direct_nodes, &iter); t != -1; t = bitset_next_member (&iter))
@@ -6248,7 +6438,7 @@ qo_discover_edges (QO_ENV * env)
 	      node = QO_ENV_NODE (env, t);
 	      if (!QO_NODE_SARGABLE (node))
 		{
-		  break;	/* give up */
+		  break;
 		}
 	    }
 

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -627,6 +627,12 @@ struct qo_term
   double selectivity;
 
   /*
+   * The largest single-MCV frequency for each join side.
+   */
+  double head_mcv_max_frequency;
+  double tail_mcv_max_frequency;
+
+  /*
    * The "flavor" of this term.  This is determined by analysis of the
    * segment or where-clause disjunct that gives rise to the term.
    */
@@ -724,6 +730,8 @@ struct qo_term
 #define QO_TERM_NODES(t)	(t)->nodes
 #define QO_TERM_SEGS(t)		(t)->segments
 #define QO_TERM_SELECTIVITY(t)	(t)->selectivity
+#define QO_TERM_HEAD_MCV_MAX_FREQUENCY(t)	(t)->head_mcv_max_frequency
+#define QO_TERM_TAIL_MCV_MAX_FREQUENCY(t)	(t)->tail_mcv_max_frequency
 #define QO_TERM_RANK(t)		(t)->rank
 #define QO_TERM_HEAD(t)		(t)->head
 #define QO_TERM_TAIL(t)		(t)->tail

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -51,6 +51,8 @@
 #include "network_interface_cl.h"
 #include "dbtype.h"
 #include "regu_var.hpp"
+#include "query_planner_internal.h"
+#include "query_planner_constants.h"
 #include "histogram_cl.hpp"
 
 #define TEST_DUMP_PLAN_SCAN_COST 0
@@ -165,19 +167,30 @@ static void qo_follow_walk (QO_PLAN *, void (*)(QO_PLAN *, void *), void *, void
 
 static void qo_plan_compute_cost (QO_PLAN *);
 static void qo_plan_compute_subquery_cost (PT_NODE *, double *, double *);
+static double qo_sum_bitset_term_cost_weights (QO_ENV *, BITSET *);
 static void qo_sscan_cost (QO_PLAN *);
+static void qo_apply_scan_term_cpu_overhead (QO_PLAN *);
 static void qo_iscan_cost (QO_PLAN *);
 static void qo_sort_cost (QO_PLAN *);
+static bool qo_can_apply_limit_card (QO_ENV *);
+static double qo_estimate_ndv (double N, double p, double n);
+static double qo_get_join_term_cost_weight (QO_TERM *);
+static double qo_sum_join_term_cost_weights (QO_ENV *, BITSET *);
+static double qo_get_nljoin_term_cpu_overhead (QO_PLAN *, double);
+static void qo_accumulate_memoize_outer_distinct_keys (QO_PLAN *, BITSET *, double, double *);
+static double qo_estimate_memoize_outer_distinct_keys (QO_PLAN *, double);
+static bool qo_is_memoize_favorable_plan (QO_PLAN *, double, double *);
+static void qo_get_non_unique_residual_lookup_costs (QO_PLAN *, double, double *, double *);
 static void qo_mjoin_cost (QO_PLAN *);
 static void qo_nljoin_cost (QO_PLAN *);
 static void qo_hjoin_cost (QO_PLAN *);
 static void qo_follow_cost (QO_PLAN *);
 static void qo_worst_cost (QO_PLAN *);
 static void qo_zero_cost (QO_PLAN *);
+static double qo_get_term_cost_weight (QO_TERM *);
 
 static void qo_estimate_ngroups (QO_PLAN *, SORT_TYPE);
 static int qo_get_group_ndv (QO_PLAN *, SORT_TYPE);
-static double qo_estimate_ndv (double N, double p, double n);
 
 static QO_PLAN *qo_top_plan_new (QO_PLAN *);
 
@@ -205,7 +218,8 @@ static double planner_nodeset_join_cost (QO_PLANNER *, BITSET *);
 static void planner_permutate (QO_PLANNER *, QO_PARTITION *, PT_HINT_ENUM, QO_NODE *, BITSET *, BITSET *, BITSET *,
 			       BITSET *, BITSET *, BITSET *, BITSET *, int, int *);
 
-static QO_PLAN *qo_find_best_nljoin_inner_plan_on_info (QO_PLAN *, QO_INFO *, JOIN_TYPE, int);
+static QO_PLAN *qo_find_best_nljoin_inner_plan_on_info (QO_PLAN *, QO_INFO *, JOIN_TYPE, BITSET *, BITSET *,
+							BITSET *, int);
 static QO_PLAN *qo_find_best_plan_on_info (QO_INFO *, QO_EQCLASS *, double);
 static bool qo_check_new_best_plan_on_info (QO_INFO *, QO_PLAN *);
 static int qo_check_plan_on_info (QO_INFO *, QO_PLAN *);
@@ -425,32 +439,8 @@ QO_PLAN_VTBL *all_vtbls[] = {
   &qo_worst_plan_vtbl
 };
 
-static double qo_or_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel);
-
-static double qo_and_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel);
-
-static double qo_not_selectivity (QO_ENV * env, double sel);
-
-static double qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static double qo_comp_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static double qo_between_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static double qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static double qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static double qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static int qo_index_cardinality (QO_ENV * env, PT_NODE * attr);
 static int qo_index_cardinality_with_dedup (QO_ENV * env, PT_NODE * attr, BITSET * seg_bitset);
 
-/*
- * log3 () -
- *   return:
- *   n(in):
- */
 static double
 log3 (double n)
 {
@@ -837,6 +827,22 @@ qo_plan_compute_subquery_cost (PT_NODE * subquery, double *subq_cpu_cost, double
     }
 
   return;
+}
+
+static double
+qo_sum_bitset_term_cost_weights (QO_ENV * env, BITSET * terms)
+{
+  BITSET_ITERATOR iter;
+  int t;
+  double sum = 0.0;
+
+  for (t = bitset_iterate (terms, &iter); t != -1; t = bitset_next_member (&iter))
+    {
+      QO_TERM *term = QO_ENV_TERM (env, t);
+      sum += qo_get_term_cost_weight (term);
+    }
+
+  return sum;
 }
 
 /*
@@ -1680,7 +1686,6 @@ qo_seq_scan_new (QO_INFO * info, QO_NODE * node)
   return plan;
 }
 
-
 /*
  * qo_sscan_cost () -
  *   return:
@@ -1690,10 +1695,16 @@ static void
 qo_sscan_cost (QO_PLAN * planp)
 {
   QO_NODE *nodep;
+  double extra_weight = 0.0;
+  double scan_rows;
 
   nodep = planp->plan_un.scan.node;
   planp->fixed_cpu_cost = 0.0;
   planp->fixed_io_cost = 0.0;
+
+  scan_rows = MAX (1, QO_NODE_NCARD (nodep));
+  planp->info->scan_rows = scan_rows;
+
   if (QO_NODE_NCARD (nodep) == 0)
     {
       planp->variable_cpu_cost = 1.0 * (double) QO_CPU_WEIGHT;
@@ -1702,8 +1713,11 @@ qo_sscan_cost (QO_PLAN * planp)
     {
       planp->variable_cpu_cost = (double) QO_NODE_NCARD (nodep) * (double) QO_CPU_WEIGHT;
     }
+
+  extra_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(QO_NODE_SARGS (nodep)));
+
+  planp->variable_cpu_cost += scan_rows * QO_CPU_WEIGHT * extra_weight * QO_SSCAN_FILTER_CPU_FACTOR;
   planp->variable_io_cost = (double) QO_NODE_TCARD (nodep);
-  planp->info->scan_rows = MAX (1, QO_NODE_NCARD (nodep));
 
 #if TEST_DUMP_PLAN_SCAN_COST
   fprintf (stdout, "\nSequential Scan Cost: \n");
@@ -1721,6 +1735,24 @@ qo_sscan_cost (QO_PLAN * planp)
     }
   fprintf (stdout, "\n");
 #endif /* TEST_DUMP_PLAN_SCAN_COST */
+}
+
+static void
+qo_apply_scan_term_cpu_overhead (QO_PLAN * planp)
+{
+  double scan_rows = MAX (1.0, planp->info->scan_rows);
+  double range_weight = 0.0;
+  double key_filter_weight = 0.0;
+  double data_filter_weight = 0.0;
+
+  range_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(planp->plan_un.scan.terms));
+
+  key_filter_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(planp->plan_un.scan.kf_terms));
+
+  data_filter_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(planp->sarged_terms));
+
+  planp->variable_cpu_cost +=
+    scan_rows * QO_CPU_WEIGHT * (1.2 * range_weight + 1.0 * key_filter_weight + 0.8 * data_filter_weight);
 }
 
 /*
@@ -2230,6 +2262,7 @@ qo_iscan_cost (QO_PLAN * planp)
   planp->variable_cpu_cost = (leaf_access + heap_access) * (double) QO_CPU_WEIGHT;
   planp->variable_io_cost = object_IO;
   planp->info->scan_rows = MAX (1, (double) QO_NODE_NCARD (nodep) * sel * filter_sel);
+  qo_apply_scan_term_cpu_overhead (planp);
 
 #if TEST_DUMP_PLAN_SCAN_COST
   fprintf (stdout, "\nIndex Scan Cost: \n");
@@ -3284,6 +3317,336 @@ qo_can_apply_limit_card (QO_ENV * env)
   return true;
 }
 
+static double
+qo_get_join_term_cost_weight (QO_TERM * term)
+{
+  PT_NODE *expr;
+
+  if (term == NULL)
+    {
+      return QO_COST_WEIGHT_JOIN_DEFAULT;
+    }
+
+  expr = QO_TERM_PT_EXPR (term);
+  if (expr == NULL || expr->node_type != PT_EXPR)
+    {
+      return QO_COST_WEIGHT_JOIN_DEFAULT;
+    }
+
+  switch (expr->info.expr.op)
+    {
+    case PT_EQ:
+    case PT_NULLSAFE_EQ:
+      {
+	PT_NODE *lhs = expr->info.expr.arg1;
+
+	if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	  {
+	    return QO_COST_WEIGHT_JOIN_STRING_EQUAL;
+	  }
+	return QO_COST_WEIGHT_JOIN_DEFAULT;
+      }
+
+    case PT_LT:
+    case PT_LE:
+    case PT_GT:
+    case PT_GE:
+    case PT_BETWEEN:
+    case PT_RANGE:
+      {
+	PT_NODE *lhs = expr->info.expr.arg1;
+
+	if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	  {
+	    return QO_COST_WEIGHT_JOIN_STRING_RANGE;
+	  }
+	return QO_COST_WEIGHT_JOIN_DEFAULT;
+      }
+
+    default:
+      return QO_COST_WEIGHT_JOIN_DEFAULT;
+    }
+}
+
+static double
+qo_sum_join_term_cost_weights (QO_ENV * env, BITSET * terms)
+{
+  BITSET_ITERATOR iter;
+  int t;
+  double sum = 0.0;
+
+  if (env == NULL || terms == NULL)
+    {
+      return 0.0;
+    }
+
+  for (t = bitset_iterate (terms, &iter); t != -1; t = bitset_next_member (&iter))
+    {
+      QO_TERM *term = QO_ENV_TERM (env, t);
+      sum += qo_get_join_term_cost_weight (term);
+    }
+
+  return sum;
+}
+
+static double
+qo_get_nljoin_term_cpu_overhead (QO_PLAN * planp, double guessed_result_cardinality)
+{
+  double join_term_weight_sum = 0.0;
+
+  if (planp == NULL || planp->plan_type != QO_PLANTYPE_JOIN || planp->info == NULL || planp->info->env == NULL)
+    {
+      return 0.0;
+    }
+
+  if (guessed_result_cardinality <= 0.0)
+    {
+      return 0.0;
+    }
+
+  /*
+   * For temporary nl-join plans used only for inner-plan search,
+   * join-term bitsets may be empty even after explicit init.
+   * That is fine; the summed overhead will become 0.
+   */
+
+  if (BITSET_IS_VALID (&(planp->plan_un.join.join_terms)))
+    {
+      join_term_weight_sum += qo_sum_join_term_cost_weights (planp->info->env, &(planp->plan_un.join.join_terms));
+    }
+  if (BITSET_IS_VALID (&(planp->plan_un.join.during_join_terms)))
+    {
+      join_term_weight_sum +=
+	qo_sum_join_term_cost_weights (planp->info->env, &(planp->plan_un.join.during_join_terms));
+    }
+
+  if (join_term_weight_sum <= 0.0)
+    {
+      return 0.0;
+    }
+
+  return guessed_result_cardinality * QO_CPU_WEIGHT * 0.5 * join_term_weight_sum;
+}
+
+static void
+qo_accumulate_memoize_outer_distinct_keys (QO_PLAN * planp, BITSET * terms, double guessed_outer_cardinality,
+					   double *best_ndvp)
+{
+  QO_PLAN *inner;
+  BITSET_ITERATOR iter;
+  int t;
+
+  if (planp == NULL || planp->plan_type != QO_PLANTYPE_JOIN || !QO_IS_NL_JOIN (planp)
+      || terms == NULL || best_ndvp == NULL || !BITSET_IS_VALID (terms))
+    {
+      return;
+    }
+
+  inner = planp->plan_un.join.inner;
+  if (inner == NULL || inner->info == NULL || !qo_is_iscan (inner))
+    {
+      return;
+    }
+
+  for (t = bitset_iterate (terms, &iter); t != -1; t = bitset_next_member (&iter))
+    {
+      QO_TERM *term = QO_ENV_TERM (planp->info->env, t);
+      PT_NODE *expr, *lhs, *rhs, *outer_attr;
+      QO_NODE *lhs_node, *rhs_node;
+      PT_NODE *dummy;
+      int ndv;
+
+      if (term == NULL || !QO_TERM_IS_FLAGED (term, QO_TERM_EQUAL_OP))
+	{
+	  continue;
+	}
+
+      expr = QO_TERM_PT_EXPR (term);
+      if (expr == NULL || expr->node_type != PT_EXPR || expr->info.expr.op != PT_EQ)
+	{
+	  continue;
+	}
+
+      lhs = expr->info.expr.arg1;
+      rhs = expr->info.expr.arg2;
+      if (lhs == NULL || rhs == NULL || qo_classify (lhs) != PC_ATTR || qo_classify (rhs) != PC_ATTR)
+	{
+	  continue;
+	}
+
+      lhs_node = lookup_node (lhs, QO_TERM_ENV (term), &dummy);
+      rhs_node = lookup_node (rhs, QO_TERM_ENV (term), &dummy);
+      if (lhs_node == NULL || rhs_node == NULL)
+	{
+	  continue;
+	}
+
+      if (BITSET_MEMBER (inner->info->nodes, QO_NODE_IDX (lhs_node)))
+	{
+	  outer_attr = rhs;
+	}
+      else if (BITSET_MEMBER (inner->info->nodes, QO_NODE_IDX (rhs_node)))
+	{
+	  outer_attr = lhs;
+	}
+      else
+	{
+	  continue;
+	}
+
+      ndv = qo_index_cardinality (QO_TERM_ENV (term), outer_attr);
+      if (ndv > 0)
+	{
+	  double clamped_ndv = MIN (guessed_outer_cardinality, (double) ndv);
+	  *best_ndvp = (*best_ndvp <= 0.0) ? clamped_ndv : MIN (guessed_outer_cardinality, *best_ndvp * clamped_ndv);
+	}
+    }
+}
+
+static double
+qo_estimate_memoize_outer_distinct_keys (QO_PLAN * planp, double guessed_outer_cardinality)
+{
+  double best_ndv = 0.0;
+
+  if (planp == NULL || planp->plan_type != QO_PLANTYPE_JOIN || !QO_IS_NL_JOIN (planp))
+    {
+      return guessed_outer_cardinality;
+    }
+
+  qo_accumulate_memoize_outer_distinct_keys (planp, &(planp->plan_un.join.join_terms), guessed_outer_cardinality,
+					     &best_ndv);
+  qo_accumulate_memoize_outer_distinct_keys (planp, &(planp->plan_un.join.during_join_terms),
+					     guessed_outer_cardinality, &best_ndv);
+
+  return (best_ndv > 0.0) ? MAX (1.0, best_ndv) : guessed_outer_cardinality;
+}
+
+static bool
+qo_is_memoize_favorable_plan (QO_PLAN * planp, double guessed_outer_cardinality, double *effective_outer_cardinality)
+{
+  QO_PLAN *inner;
+  QO_INDEX_ENTRY *index_entryp;
+  double inner_cardinality;
+  double miss_cardinality;
+  double outer_distinct_keys;
+  bool unique_lookup;
+
+  if (effective_outer_cardinality != NULL)
+    {
+      *effective_outer_cardinality = guessed_outer_cardinality;
+    }
+
+  if (planp == NULL || planp->plan_type != QO_PLANTYPE_JOIN || !QO_IS_NL_JOIN (planp))
+    {
+      return false;
+    }
+
+  inner = planp->plan_un.join.inner;
+  if (inner == NULL || inner->info == NULL || !qo_is_iscan (inner) || inner->plan_un.scan.index == NULL
+      || inner->plan_un.scan.index->head == NULL)
+    {
+      return false;
+    }
+
+  index_entryp = inner->plan_un.scan.index->head;
+  unique_lookup =
+    qo_is_all_unique_index_columns_are_equi_terms (inner)
+    || (index_entryp->constraints != NULL && SM_IS_CONSTRAINT_UNIQUE_FAMILY (index_entryp->constraints->type)
+	&& (BITSET_IS_VALID (&(planp->plan_un.join.join_terms))
+	    || BITSET_IS_VALID (&(planp->plan_un.join.during_join_terms))));
+
+  if (!unique_lookup)
+    {
+      return false;
+    }
+
+  inner_cardinality = MAX (1.0, inner->info->cardinality);
+  if (guessed_outer_cardinality <= inner_cardinality)
+    {
+      return false;
+    }
+
+  if (effective_outer_cardinality != NULL)
+    {
+      outer_distinct_keys = qo_estimate_memoize_outer_distinct_keys (planp, guessed_outer_cardinality);
+      miss_cardinality = MIN (guessed_outer_cardinality, outer_distinct_keys);
+      *effective_outer_cardinality =
+	miss_cardinality + (guessed_outer_cardinality - miss_cardinality) * QO_NLJOIN_MEMOIZE_HIT_COST_RATIO;
+    }
+
+  return true;
+}
+
+static void
+qo_get_non_unique_residual_lookup_costs (QO_PLAN * planp, double outer_cardinality, double *cpu_costp, double *io_costp)
+{
+  QO_PLAN *inner;
+  QO_INDEX_ENTRY *index_entryp;
+  QO_ATTR_CUM_STATS *cum_statsp;
+  double rows_per_lookup;
+  double residual_weight;
+  double heap_io_per_lookup;
+  int pkeys_num;
+
+  if (cpu_costp != NULL)
+    {
+      *cpu_costp = 0.0;
+    }
+  if (io_costp != NULL)
+    {
+      *io_costp = 0.0;
+    }
+
+  if (planp == NULL || planp->plan_type != QO_PLANTYPE_JOIN || !QO_IS_NL_JOIN (planp))
+    {
+      return;
+    }
+
+  inner = planp->plan_un.join.inner;
+  if (inner == NULL || inner->info == NULL || !qo_is_iscan (inner) || inner->plan_un.scan.index == NULL
+      || inner->plan_un.scan.index->head == NULL || bitset_is_empty (&(inner->sarged_terms)))
+    {
+      return;
+    }
+
+  index_entryp = inner->plan_un.scan.index->head;
+  if (index_entryp->constraints != NULL && SM_IS_CONSTRAINT_UNIQUE_FAMILY (index_entryp->constraints->type))
+    {
+      return;
+    }
+
+  cum_statsp = &(inner->plan_un.scan.index->cum_stats);
+  pkeys_num = MIN (index_entryp->col_num, cum_statsp->pkeys_size);
+  if (pkeys_num <= 0 || cum_statsp->pkeys == NULL || cum_statsp->pkeys[0] <= 0)
+    {
+      return;
+    }
+
+  rows_per_lookup = (double) QO_NODE_NCARD (inner->plan_un.scan.node) / (double) cum_statsp->pkeys[0];
+  if (rows_per_lookup <= 1.0)
+    {
+      return;
+    }
+
+  residual_weight = qo_sum_bitset_term_cost_weights (inner->info->env, &(inner->sarged_terms));
+  if (cpu_costp != NULL && residual_weight > 0.0)
+    {
+      /*
+       * A non-unique lookup reads candidate tuples before residual predicates
+       * can discard them. Charge both tuple visitation and residual predicate
+       * evaluation per candidate row.
+       */
+      *cpu_costp =
+	outer_cardinality * rows_per_lookup * (QO_COST_WEIGHT_PRED_DEFAULT + residual_weight) * QO_CPU_WEIGHT;
+    }
+
+  if (io_costp != NULL && !qo_is_index_covering_scan (inner))
+    {
+      heap_io_per_lookup = rows_per_lookup / (double) ISCAN_OID_ACCESS_OVERHEAD;
+      *io_costp = outer_cardinality * heap_io_per_lookup * (1 - ISCAN_IO_HIT_RATIO);
+    }
+}
+
 /*
  * qo_nljoin_cost () -
  *   return:
@@ -3295,6 +3658,8 @@ qo_nljoin_cost (QO_PLAN * planp)
   QO_PLAN *inner, *outer;
   double inner_io_cost, inner_cpu_cost, outer_io_cost, outer_cpu_cost;
   double guessed_result_cardinality, limit_val, outer_card;
+  double inner_cost_cardinality;
+  double non_unique_residual_lookup_cpu_cost, non_unique_residual_lookup_io_cost;
 
   inner = planp->plan_un.join.inner;
 
@@ -3356,12 +3721,19 @@ qo_nljoin_cost (QO_PLAN * planp)
     {
       guessed_result_cardinality = (outer->info)->cardinality;
     }
-  inner_cpu_cost = guessed_result_cardinality * inner->variable_cpu_cost;
+
+  inner_cost_cardinality = guessed_result_cardinality;
+  (void) qo_is_memoize_favorable_plan (planp, guessed_result_cardinality, &inner_cost_cardinality);
+  qo_get_non_unique_residual_lookup_costs (planp, inner_cost_cardinality, &non_unique_residual_lookup_cpu_cost,
+					   &non_unique_residual_lookup_io_cost);
+
+  inner_cpu_cost = inner_cost_cardinality * inner->variable_cpu_cost + non_unique_residual_lookup_cpu_cost;
 
   /* inner side IO cost of nested-loop block join */
   if (qo_is_iscan (inner))
     {
-      inner_io_cost = guessed_result_cardinality * inner->variable_io_cost * (1 - ISCAN_IO_HIT_RATIO);
+      inner_io_cost = inner_cost_cardinality * inner->variable_io_cost * (1 - ISCAN_IO_HIT_RATIO);
+      inner_io_cost += non_unique_residual_lookup_io_cost;
     }
   else
     {
@@ -3414,6 +3786,11 @@ qo_nljoin_cost (QO_PLAN * planp)
     /* subq cost is already included in the inner. so add it for the cardinality excluded due to ISCAN_IO_HIT_RATIO. */
     planp->variable_cpu_cost += guessed_result_cardinality * ISCAN_IO_HIT_RATIO * subq_cpu_cost;
     planp->variable_io_cost += guessed_result_cardinality * ISCAN_IO_HIT_RATIO * subq_io_cost;	/* assume IO as # blocks */
+
+    if (planp->info->env && BITSET_IS_VALID (&(planp->plan_un.join.join_terms)))
+      {
+	planp->variable_cpu_cost += qo_get_nljoin_term_cpu_overhead (planp, guessed_result_cardinality);
+      }
   }
 
 #if TEST_DUMP_PLAN_JOIN_COST
@@ -3988,7 +4365,6 @@ qo_zero_cost (QO_PLAN * planp)
   planp->variable_io_cost = 0.0;
 }
 
-
 /*
  * qo_plan_order_by () -
  *   return:
@@ -4100,7 +4476,6 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
   bf = b->fixed_cpu_cost + b->fixed_io_cost;
   ba = b->variable_cpu_cost + b->variable_io_cost;
 
-  /* Check if RBO is needed */
   ta = af + aa;
   tb = bf + ba;
   if (ta > 0 && tb > 0 && QO_PLAN_HAS_LIMIT (a) && QO_PLAN_HAS_LIMIT (b))
@@ -5919,7 +6294,6 @@ qo_check_new_best_plan_on_info (QO_INFO * info, QO_PLAN * plan)
 static int
 qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
 {
-  QO_INFO *best_info;
   QO_EQCLASS *plan_order;
   QO_PLAN_COMPARE_RESULT cmp;
   bool found_new_best;
@@ -5931,7 +6305,6 @@ qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
 
   /* init */
   found_new_best = false;
-  best_info = info->planner->best_info;
   plan_order = plan->order;
 
   /* if the plan is of type QO_SCANMETHOD_INDEX_ORDERBY_SCAN but it doesn't skip the orderby, we release the plan. */
@@ -5947,25 +6320,6 @@ qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
     {
       qo_plan_release (plan);
       return 0;
-    }
-
-  /*
-   * If the cost of the new Plan already exceeds the cost of the best
-   * known solution with the same order, there is no point in
-   * remembering the new plan.
-   */
-  if (best_info)
-    {
-      cmp =
-	qo_cmp_planvec (plan_order ==
-			QO_UNORDERED ? &best_info->best_no_order : &best_info->planvec[QO_EQCLASS_IDX (plan_order)],
-			plan);
-      /* cmp : PLAN_COMP_UNK, PLAN_COMP_LT, PLAN_COMP_EQ, PLAN_COMP_GT */
-      if (cmp == PLAN_COMP_LT || cmp == PLAN_COMP_EQ)
-	{
-	  qo_plan_release (plan);
-	  return 0;
-	}
     }
 
   /*
@@ -6018,7 +6372,8 @@ qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
  *   idx_join_plan_n(in):
  */
 static QO_PLAN *
-qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TYPE join_type, int idx_join_plan_n)
+qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TYPE join_type, BITSET * join_terms,
+					BITSET * duj_terms, BITSET * afj_terms, int idx_join_plan_n)
 {
   QO_PLANVEC *pv;
   QO_PLAN *temp, *best_plan, *inner;
@@ -6045,6 +6400,17 @@ qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TY
   temp->plan_type = QO_PLANTYPE_JOIN;
   temp->plan_un.join.join_type = join_type;	/* set nl-join type */
   temp->plan_un.join.outer = outer;	/* set outer */
+
+  bitset_init (&(temp->plan_un.join.join_terms), info->env);
+  bitset_init (&(temp->plan_un.join.during_join_terms), info->env);
+  bitset_init (&(temp->plan_un.join.after_join_terms), info->env);
+
+  bitset_assign (&(temp->plan_un.join.join_terms), join_terms);
+  if (IS_OUTER_JOIN_TYPE (join_type))
+    {
+      bitset_assign (&(temp->plan_un.join.during_join_terms), duj_terms);
+      bitset_assign (&(temp->plan_un.join.after_join_terms), afj_terms);
+    }
 
   temp->multi_range_opt_use = PLAN_MULTI_RANGE_OPT_NO;
 
@@ -6075,6 +6441,9 @@ qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TY
   /* free temp plan */
   temp->plan_un.join.outer = NULL;
   temp->plan_un.join.inner = NULL;
+  bitset_delset (&(temp->plan_un.join.join_terms));
+  bitset_delset (&(temp->plan_un.join.during_join_terms));
+  bitset_delset (&(temp->plan_un.join.after_join_terms));
 
   qo_plan_add_to_free_list (temp, NULL);
 
@@ -6276,7 +6645,9 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
 	{
 	  goto exit;
 	}
-      inner_plan = qo_find_best_nljoin_inner_plan_on_info (outer_plan, outer, join_type, idx_join_plan_n);
+      inner_plan =
+	qo_find_best_nljoin_inner_plan_on_info (outer_plan, outer, join_type, nl_join_terms, duj_terms, afj_terms,
+						idx_join_plan_n);
       if (inner_plan == NULL)
 	{
 	  goto exit;
@@ -6310,7 +6681,9 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
 	{
 	  goto exit;
 	}
-      inner_plan = qo_find_best_nljoin_inner_plan_on_info (outer_plan, inner, join_type, idx_join_plan_n);
+      inner_plan =
+	qo_find_best_nljoin_inner_plan_on_info (outer_plan, inner, join_type, nl_join_terms, duj_terms, afj_terms,
+						idx_join_plan_n);
       if (inner_plan == NULL)
 	{
 	  goto exit;
@@ -6562,17 +6935,17 @@ qo_examine_hash_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_I
   /* A query using a predicate for an oid is rewritten as a path join query.  The path join query is executed
    * as a left outer join, so if the path join query is not executed with a follow plan, results with NULL values
    * are retrieved even if the join predicate is not satisfied.
-   * 
+   *
    *   e.g. drop table if exists t;
    *        create table t (c int) dont_reuse_oid;
    *        insert into t values (1);
    *        select dual into :dummy_oid from dual limit 1;
-   * 
+   *
    *        select * from t where t = :dummy_oid;
    *
    *        -- rewritten query
    *        select dt_1.da_2.t.c from table({:dummy_oid}) dt_1 (da_2)
-   * 
+   *
    *        -- Query plan: follow
    *        There are no results.
    *        0 row selected.
@@ -6580,7 +6953,7 @@ qo_examine_hash_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_I
    *        -- Query plan: hash-join (left outer join)
    *        c1: NULL
    *        1 row selected.
-   * 
+   *
    * This code prevents the path join query from being executed as a hash join plan rather than as a follow plan.
    */
   for (bitset_index = bitset_iterate (hash_join_terms, &bitset_iter); bitset_index != -1;
@@ -7835,7 +8208,9 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 		}
 	      else
 		{
-		  selectivity *= QO_TERM_SELECTIVITY (term);
+		  double term_sel = QO_TERM_SELECTIVITY (term);
+
+		  selectivity *= term_sel;
 		  selectivity = MAX (1.0 / MAX (cardinality, 1.0), selectivity);
 
 		  double head_factor, tail_factor;
@@ -9680,1191 +10055,12 @@ qo_combine_partitions (QO_PLANNER * planner, BITSET * reamining_subqueries)
 }
 
 /*
- * qo_expr_selectivity () -
- *   return: double
- *   env(in): optimizer environment
- *   pt_expr(in): expression to evaluate
- */
-double
-qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  double lhs_selectivity, rhs_selectivity, selectivity, total_selectivity;
-  PT_NODE *node;
-  bool not_null_calculated = false;
-
-  QO_ASSERT (env, pt_expr != NULL);
-  QO_ASSERT (env, pt_expr->node_type == PT_EXPR);
-
-  selectivity = 0.0;
-  total_selectivity = 0.0;
-
-  /* traverse OR list */
-  for (node = pt_expr; node; node = node->or_next)
-    {
-      switch (node->info.expr.op)
-	{
-	case PT_OR:
-	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
-	  rhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg2);
-	  selectivity = qo_or_selectivity (env, lhs_selectivity, rhs_selectivity);
-	  break;
-
-	case PT_AND:
-	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
-	  rhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg2);
-	  selectivity = qo_and_selectivity (env, lhs_selectivity, rhs_selectivity);
-	  break;
-
-	case PT_NOT:
-	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
-	  selectivity = qo_not_selectivity (env, lhs_selectivity);
-	  break;
-
-	case PT_EQ:
-	  selectivity = qo_equal_selectivity (env, node);
-	  break;
-
-	case PT_NE:
-	  lhs_selectivity = qo_equal_selectivity (env, node);
-	  selectivity = qo_not_selectivity (env, lhs_selectivity);
-	  break;
-
-	case PT_NULLSAFE_EQ:
-	  selectivity = qo_equal_selectivity (env, node);
-	  break;
-
-	case PT_GE:
-	case PT_GT:
-	case PT_LT:
-	case PT_LE:
-	  selectivity = qo_comp_selectivity (env, node);
-	  break;
-
-	case PT_BETWEEN:
-	  selectivity = qo_between_selectivity (env, node);
-	  break;
-
-	case PT_NOT_BETWEEN:
-	  lhs_selectivity = qo_between_selectivity (env, node);
-	  selectivity = qo_not_selectivity (env, lhs_selectivity);
-	  break;
-
-	case PT_RANGE:
-	  selectivity = qo_range_selectivity (env, node);
-	  break;
-
-	case PT_LIKE_ESCAPE:
-	  selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
-	  break;
-	case PT_LIKE:
-	  {
-	    selectivity = qo_like_selectivity (env, pt_expr);
-	    break;
-	  }
-	case PT_NOT_LIKE:
-	  {
-	    selectivity = 1 - qo_like_selectivity (env, pt_expr);
-	    break;
-	  }
-	case PT_SETNEQ:
-	case PT_SETEQ:
-	case PT_SUPERSETEQ:
-	case PT_SUPERSET:
-	case PT_SUBSET:
-	case PT_SUBSETEQ:
-	case PT_IS:
-	case PT_XOR:
-	  selectivity = DEFAULT_SELECTIVITY;
-	  break;
-
-	case PT_IS_NOT:
-	  selectivity = qo_not_selectivity (env, DEFAULT_SELECTIVITY);
-	  break;
-
-	case PT_EQ_SOME:
-	case PT_NE_SOME:
-	case PT_GE_SOME:
-	case PT_GT_SOME:
-	case PT_LT_SOME:
-	case PT_LE_SOME:
-	case PT_EQ_ALL:
-	case PT_NE_ALL:
-	case PT_GE_ALL:
-	case PT_GT_ALL:
-	case PT_LT_ALL:
-	case PT_LE_ALL:
-	case PT_IS_IN:
-	  selectivity = qo_all_some_in_selectivity (env, node);
-	  break;
-
-	case PT_IS_NOT_IN:
-	  lhs_selectivity = qo_all_some_in_selectivity (env, node);
-	  selectivity = qo_not_selectivity (env, lhs_selectivity);
-	  break;
-
-	case PT_IS_NULL:
-	  if (pt_expr->info.expr.arg1->node_type == PT_NAME && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
-	    {
-	      selectivity = pt_expr->info.expr.arg1->info.name.null_frequency;
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_NULL_SELECTIVITY;
-	    }
-	  not_null_calculated = true;
-	  break;
-
-	case PT_IS_NOT_NULL:
-	  if (pt_expr->info.expr.arg1->node_type == PT_NAME && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
-	    {
-	      selectivity = pt_expr->info.expr.arg1->info.name.null_frequency;
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_NULL_SELECTIVITY;
-	    }
-	  selectivity = 1 - selectivity;
-	  not_null_calculated = true;
-	  break;
-
-	case PT_EXISTS:
-	  selectivity = DEFAULT_EXISTS_SELECTIVITY;	/* make a guess */
-	  break;
-
-	default:
-	  break;
-	}
-
-      if (!not_null_calculated)
-	{
-	  if (pt_expr->info.expr.arg1 && pt_expr->info.expr.arg1->node_type == PT_NAME
-	      && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
-	    {
-	      selectivity = selectivity * (1 - pt_expr->info.expr.arg1->info.name.null_frequency);
-	    }
-	  if (pt_expr->info.expr.arg2 && pt_expr->info.expr.arg2->node_type == PT_NAME
-	      && pt_expr->info.expr.arg2->info.name.null_frequency >= 0.0)
-	    {
-	      selectivity = selectivity * (1 - pt_expr->info.expr.arg2->info.name.null_frequency);
-	    }
-	}
-
-      total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);
-      total_selectivity = MAX (total_selectivity, 0.0);
-      total_selectivity = MIN (total_selectivity, 1.0);
-    }
-
-  return total_selectivity;
-}
-
-static double
-qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PT_NODE *lhs, *rhs;
-  DB_VALUE *host_var = NULL;
-  PRED_CLASS pc_lhs, pc_rhs;
-
-  double selectivity;
-  double total_selectivity = 0.0;
-
-  PT_NODE *like_node;
-
-  for (like_node = pt_expr; like_node; like_node = like_node->or_next)
-    {
-      bool success = false;
-
-      lhs = like_node->info.expr.arg1;
-      rhs = like_node->info.expr.arg2;
-
-      if (lhs && rhs)
-	{
-	  pc_lhs = qo_classify (lhs);
-	  pc_rhs = qo_classify (rhs);
-
-	  if (pc_lhs == PC_ATTR)
-	    {
-	      if (pc_rhs == PC_CONST)
-		{
-		  host_var = &rhs->info.value.db_value;
-		}
-	      else if (pc_rhs == PC_HOST_VAR)
-		{
-		  host_var = &env->parser->host_variables[rhs->info.host_var.index];
-		}
-
-	      histogram_get_like_selectivity (lhs, host_var, &selectivity, &success);
-
-	      if (!success)
-		{
-		  selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
-		}
-	    }
-	  else
-	    {
-	      selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
-	    }
-
-	  total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);
-	  total_selectivity = MAX (total_selectivity, 0.0);
-	  total_selectivity = MIN (total_selectivity, 1.0);
-	}
-
-    }
-
-
-  return total_selectivity;
-}
-
-/*
- * qo_or_selectivity () - Calculate the selectivity of an OR expression
- *                        from the selectivities of the lhs and rhs
- *   return: double
- *   env(in):
- *   lhs_sel(in):
- *   rhs_sel(in):
- */
-static double
-qo_or_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel)
-{
-  double result;
-
-  QO_ASSERT (env, lhs_sel >= 0.0);
-  QO_ASSERT (env, lhs_sel <= 1.0);
-  QO_ASSERT (env, rhs_sel >= 0.0);
-  QO_ASSERT (env, rhs_sel <= 1.0);
-
-  result = lhs_sel + rhs_sel - (lhs_sel * rhs_sel);
-
-  return result;
-}
-
-/*
- * qo_and_selectivity () -
- *   return:
- *   env(in):
- *   lhs_sel(in):
- *   rhs_sel(in):
- */
-static double
-qo_and_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel)
-{
-  double result;
-
-  QO_ASSERT (env, lhs_sel >= 0.0);
-  QO_ASSERT (env, lhs_sel <= 1.0);
-  QO_ASSERT (env, rhs_sel >= 0.0);
-  QO_ASSERT (env, rhs_sel <= 1.0);
-
-  result = lhs_sel * rhs_sel;
-
-  return result;
-}
-
-/*
- * qo_not_selectivity () - Calculate the selectivity of a not expresssion
- *   return: double
- *   env(in):
- *   sel(in):
- */
-static double
-qo_not_selectivity (QO_ENV * env, double sel)
-{
-  QO_ASSERT (env, sel >= 0.0);
-  QO_ASSERT (env, sel <= 1.0);
-
-  return 1.0 - sel;
-}
-
-/*
- * qo_equal_selectivity () - Compute the selectivity of an equality predicate
- *   return: double
- *   env(in):
- *   pt_expr(in):
- *
- * Note: This uses the System R algorithm
- */
-static double
-qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PT_NODE *lhs, *rhs, *multi_attr;
-  DB_VALUE *host_var;
-  PRED_CLASS pc_lhs, pc_rhs;
-  int lhs_icard, rhs_icard, icard;
-  double selectivity;
-
-  lhs = pt_expr->info.expr.arg1;
-  rhs = pt_expr->info.expr.arg2;
-
-  /* the class of lhs and rhs */
-  pc_lhs = qo_classify (lhs);
-  pc_rhs = qo_classify (rhs);
-
-  selectivity = DEFAULT_EQUAL_SELECTIVITY;
-
-  bool success = false;
-
-  switch (pc_lhs)
-    {
-    case PC_ATTR:
-
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  /* attr = attr */
-
-	  /* check for indexes on either of the attributes */
-	  lhs_icard = qo_index_cardinality (env, lhs);
-	  rhs_icard = qo_index_cardinality (env, rhs);
-
-	  icard = MAX (lhs_icard, rhs_icard);
-	  if (icard != 0)
-	    {
-	      selectivity = (1.0 / icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
-	    }
-
-	  /* TODO: add histogram selectivity */
-	  break;
-
-	case PC_CONST:
-	case PC_HOST_VAR:
-	  if (pc_rhs == PC_HOST_VAR)
-	    {
-	      host_var = &env->parser->host_variables[rhs->info.host_var.index];
-	    }
-	  else
-	    {
-	      host_var = &rhs->info.value.db_value;
-	    }
-	  histogram_get_equal_selectivity (lhs, host_var, &selectivity, &success);
-	  if (success)
-	    {
-	      break;
-	    }
-	  [[fallthrough]];
-
-	case PC_SUBQUERY:
-	case PC_SET:
-	case PC_OTHER:
-	  /* attr = const */
-
-	  /* check for index on the attribute.  NOTE: For an equality predicate, we treat subqueries as constants. */
-	  lhs_icard = qo_index_cardinality (env, lhs);
-	  if (lhs_icard != 0)
-	    {
-	      selectivity = (1.0 / lhs_icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	    }
-
-	  break;
-
-	case PC_MULTI_ATTR:
-	  /* attr = (attr,attr) syntactic impossible case */
-	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	  break;
-	}
-
-      break;
-
-    case PC_CONST:
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  histogram_get_equal_selectivity (rhs, &lhs->info.value.db_value, &selectivity, &success);
-	  break;
-
-	default:
-	  break;
-	}
-      if (success)
-	{
-	  break;
-	}
-      [[fallthrough]];
-
-    case PC_HOST_VAR:
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  host_var = &env->parser->host_variables[lhs->info.host_var.index];
-	  histogram_get_equal_selectivity (rhs, host_var, &selectivity, &success);
-	  break;
-
-	default:
-	  break;
-	}
-      if (success)
-	{
-	  break;
-	}
-      [[fallthrough]];
-    case PC_SUBQUERY:
-    case PC_SET:
-    case PC_OTHER:
-
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  /* const = attr */
-
-	  /* check for index on the attribute.  NOTE: For an equality predicate, we treat subqueries as constants. */
-	  rhs_icard = qo_index_cardinality (env, rhs);
-	  if (rhs_icard != 0)
-	    {
-	      selectivity = (1.0 / rhs_icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	    }
-
-	  break;
-
-	case PC_CONST:
-	case PC_HOST_VAR:
-	case PC_SUBQUERY:
-	case PC_SET:
-	case PC_OTHER:
-	  /* const = const */
-
-	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	  break;
-
-	case PC_MULTI_ATTR:
-	  /* const = (attr,attr) */
-	  multi_attr = rhs->info.function.arg_list;
-	  rhs_icard = 0;
-	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
-	    {
-	      /* get index cardinality */
-	      icard = qo_index_cardinality (env, multi_attr);
-	      if (icard <= 0)
-		{
-		  /* the only interesting case is PT_BETWEEN_EQ_NA */
-		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
-		}
-	      if (rhs_icard == 0)
-		{
-		  /* first time */
-		  rhs_icard = icard;
-		}
-	      else
-		{
-		  rhs_icard *= icard;
-		}
-	    }
-	  if (rhs_icard != 0)
-	    {
-	      selectivity = (1.0 / rhs_icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	    }
-	  break;
-	}
-      break;
-
-    case PC_MULTI_ATTR:
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  /* (attr,attr) = attr  syntactic impossible case */
-	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	  break;
-
-	case PC_CONST:
-	case PC_HOST_VAR:
-	case PC_SUBQUERY:
-	case PC_SET:
-	case PC_OTHER:
-	  /* (attr,attr) = const */
-
-	  multi_attr = lhs->info.function.arg_list;
-	  lhs_icard = 0;
-	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
-	    {
-	      /* get index cardinality */
-	      icard = qo_index_cardinality (env, multi_attr);
-	      if (icard <= 0)
-		{
-		  /* the only interesting case is PT_BETWEEN_EQ_NA */
-		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
-		}
-	      if (lhs_icard == 0)
-		{
-		  /* first time */
-		  lhs_icard = icard;
-		}
-	      else
-		{
-		  lhs_icard *= icard;
-		}
-	    }
-	  if (lhs_icard != 0)
-	    {
-	      selectivity = (1.0 / lhs_icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	    }
-	  break;
-
-	case PC_MULTI_ATTR:
-	  /* (attr,attr) = (attr,attr) */
-	  multi_attr = lhs->info.function.arg_list;
-	  lhs_icard = 0;
-	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
-	    {
-	      /* get index cardinality */
-	      icard = qo_index_cardinality (env, multi_attr);
-	      if (icard <= 0)
-		{
-		  /* the only interesting case is PT_BETWEEN_EQ_NA */
-		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
-		}
-	      if (lhs_icard == 0)
-		{
-		  /* first time */
-		  lhs_icard = icard;
-		}
-	      else
-		{
-		  lhs_icard *= icard;
-		}
-	    }
-
-	  multi_attr = rhs->info.function.arg_list;
-	  rhs_icard = 0;
-	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
-	    {
-	      /* get index cardinality */
-	      icard = qo_index_cardinality (env, multi_attr);
-	      if (icard <= 0)
-		{
-		  /* the only interesting case is PT_BETWEEN_EQ_NA */
-		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
-		}
-	      if (rhs_icard == 0)
-		{
-		  /* first time */
-		  rhs_icard = icard;
-		}
-	      else
-		{
-		  rhs_icard *= icard;
-		}
-	    }
-
-	  icard = MAX (lhs_icard, rhs_icard);
-	  if (icard != 0)
-	    {
-	      selectivity = (1.0 / icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
-	    }
-	  break;
-	}
-
-      break;
-      break;
-    }
-
-  return selectivity;
-}
-
-/*
- * qo_comp_selectivity () - Compute the selectivity of a comparison predicate.
- *   return: double
- *   env(in): Pointer to an environment structure
- *   pt_expr(in): comparison expression
- *
- * Note: This uses the System R algorithm
- */
-static double
-qo_comp_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PT_NODE *lhs, *rhs, *multi_attr;
-  PRED_CLASS pc_lhs, pc_rhs;
-  DB_VALUE *rhs_db_value;
-  DB_VALUE *lhs_db_value;
-  int lhs_icard, rhs_icard, icard;
-  double selectivity;
-
-  lhs = pt_expr->info.expr.arg1;
-  rhs = pt_expr->info.expr.arg2;
-
-  /* the class of lhs and rhs */
-  pc_lhs = qo_classify (lhs);
-  pc_rhs = qo_classify (rhs);
-
-  selectivity = DEFAULT_COMP_SELECTIVITY;
-
-  bool success = false;
-  switch (pc_lhs)
-    {
-    case PC_ATTR:
-
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  /* TODO: add histogram selectivity */
-	  break;
-
-	case PC_CONST:
-	case PC_HOST_VAR:
-	  {
-	    if (pc_rhs == PC_HOST_VAR)
-	      {
-		rhs_db_value = &env->parser->host_variables[rhs->info.host_var.index];
-	      }
-	    else
-	      {
-		rhs_db_value = &rhs->info.value.db_value;
-	      }
-
-	    if (pt_expr->info.expr.op == PT_GE)
-	      {
-		histogram_get_comp_selectivity (lhs, rhs_db_value, true, true, &selectivity, &success);
-	      }
-	    else if (pt_expr->info.expr.op == PT_GT)
-	      {
-		histogram_get_comp_selectivity (lhs, rhs_db_value, true, false, &selectivity, &success);
-	      }
-	    else if (pt_expr->info.expr.op == PT_LE)
-	      {
-		histogram_get_comp_selectivity (lhs, rhs_db_value, false, true, &selectivity, &success);
-	      }
-	    else if (pt_expr->info.expr.op == PT_LT)
-	      {
-		histogram_get_comp_selectivity (lhs, rhs_db_value, false, false, &selectivity, &success);
-	      }
-	  }
-	  break;
-
-	default:
-	  break;
-	}
-
-      break;
-
-    case PC_CONST:
-    case PC_HOST_VAR:
-      {
-	switch (pc_rhs)
-	  {
-	  case PC_ATTR:
-	    {
-	      if (pc_lhs == PC_HOST_VAR)
-		{
-		  lhs_db_value = &env->parser->host_variables[lhs->info.host_var.index];
-		}
-	      else
-		{
-		  lhs_db_value = &lhs->info.value.db_value;
-		}
-	      if (pt_expr->info.expr.op == PT_GE)
-		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, false, &selectivity, &success);
-		}
-	      else if (pt_expr->info.expr.op == PT_GT)
-		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, true, &selectivity, &success);
-		}
-	      else if (pt_expr->info.expr.op == PT_LE)
-		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, false, &selectivity, &success);
-		}
-	      else if (pt_expr->info.expr.op == PT_LT)
-		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, true, &selectivity, &success);
-		}
-	      break;
-	    }
-	  default:
-	    break;
-	  }
-      }
-      break;
-
-    case PC_MULTI_ATTR:
-      switch (pc_rhs)
-	{
-	case PC_MULTI_ATTR:
-	  /* (attr,attr) = (attr,attr) */
-	  /* TODO: add histogram selectivity */
-	  break;
-
-	default:
-	  break;
-	}
-
-      break;
-    default:
-      break;
-    }
-
-  return success ? selectivity : DEFAULT_COMP_SELECTIVITY;
-}
-
-/*
- * qo_between_selectivity () - Compute the selectivity of a between predicate
- *   return: double
- *   env(in): Pointer to an environment structure
- *   pt_expr(in): between expression
- *
- * Note: This uses the System R algorithm
- */
-static double
-qo_between_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PT_NODE *and_node;
-
-  and_node = pt_expr->info.expr.arg2;
-
-  QO_ASSERT (env, and_node->node_type == PT_EXPR);
-  QO_ASSERT (env, pt_is_between_range_op (and_node->info.expr.op));
-
-  return DEFAULT_BETWEEN_SELECTIVITY;
-}
-
-/*
- * qo_range_selectivity () -
- *   return:
- *   env(in):
- *   pt_expr(in):
- */
-static double
-qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PT_NODE *lhs, *arg1, *arg2;
-  DB_VALUE *lhs_db_value;
-  DB_VALUE *arg1_db_value;
-  DB_VALUE *arg2_db_value;
-  PRED_CLASS pc1, pc2;
-  PRED_CLASS pc_arg1, pc_arg2;
-
-  double total_selectivity;
-  double selectivity = DEFAULT_BETWEEN_SELECTIVITY;
-  int lhs_icard = 0, rhs_icard = 0, icard = 0;
-  PT_NODE *range_node;
-  PT_OP_TYPE op_type;
-
-  lhs = pt_expr->info.expr.arg1;
-
-  pc2 = qo_classify (lhs);
-
-  /* the only interesting case is 'attr RANGE {=1,=2}' or '(attr,attr) RANGE {={..},..}' */
-  if (pc2 == PC_MULTI_ATTR)
-    {
-      lhs = lhs->info.function.arg_list;
-      lhs_icard = 0;
-      for ( /* none */ ; lhs; lhs = lhs->next)
-	{
-	  /* get index cardinality */
-	  icard = qo_index_cardinality (env, lhs);
-	  if (icard <= 0)
-	    {
-	      /* the only interesting case is PT_BETWEEN_EQ_NA */
-	      icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
-	    }
-	  if (lhs_icard == 0)
-	    {
-	      /* first time */
-	      lhs_icard = icard;
-	    }
-	  else
-	    {
-	      lhs_icard *= icard;
-	    }
-	}
-    }
-  else if (pc2 == PC_ATTR)
-    {
-      /* get index cardinality */
-      lhs_icard = qo_index_cardinality (env, lhs);
-    }
-  else
-    {
-      return DEFAULT_RANGE_SELECTIVITY;
-    }
-#if 1				/* unused anymore - DO NOT DELETE ME */
-  QO_ASSERT (env, !PT_EXPR_INFO_IS_FLAGED (pt_expr, PT_EXPR_INFO_FULL_RANGE));
-#endif
-
-  total_selectivity = 0.0;
-
-  for (range_node = pt_expr->info.expr.arg2; range_node; range_node = range_node->or_next)
-    {
-      QO_ASSERT (env, range_node->node_type == PT_EXPR);
-
-      op_type = range_node->info.expr.op;
-      QO_ASSERT (env, pt_is_between_range_op (op_type));
-
-      arg1 = range_node->info.expr.arg1;
-      arg2 = range_node->info.expr.arg2;
-
-      pc_arg1 = qo_classify (arg1);
-      pc1 = pc_arg1;
-
-      if (pc_arg1 == PC_HOST_VAR)
-	{
-	  arg1_db_value = &env->parser->host_variables[arg1->info.host_var.index];
-	}
-      else if (pc_arg1 == PC_CONST)
-	{
-	  arg1_db_value = &arg1->info.value.db_value;
-	}
-      else
-	{
-	  arg1_db_value = NULL;
-	}
-
-      if (arg2 != NULL)
-	{
-	  pc_arg2 = qo_classify (arg2);
-
-	  if (pc_arg2 == PC_HOST_VAR)
-	    {
-	      arg2_db_value = &env->parser->host_variables[arg2->info.host_var.index];
-	    }
-	  else if (pc_arg2 == PC_CONST)
-	    {
-	      arg2_db_value = &arg2->info.value.db_value;
-	    }
-	  else
-	    {
-	      arg2_db_value = NULL;
-	    }
-	}
-      else
-	{
-	  arg2_db_value = NULL;
-	}
-
-      if (op_type == PT_BETWEEN_GE_LE || op_type == PT_BETWEEN_GE_LT || op_type == PT_BETWEEN_GT_LE
-	  || op_type == PT_BETWEEN_GT_LT || op_type == PT_BETWEEN_INF_LT || op_type == PT_BETWEEN_INF_LE
-	  || op_type == PT_BETWEEN_GE_INF || op_type == PT_BETWEEN_GT_INF)
-	{
-	  double selectivity_a = 0.0, selectivity_b = 0.0, selectivity_backup = selectivity;
-	  bool success1 = false;
-	  bool success2 = false;
-	  switch (op_type)
-	    {
-	    case PT_BETWEEN_GE_LE:
-	      {
-		/* selectivity = sel_le(b) - sel_lt(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, true, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GE_LT:
-	      {
-		/* selectivity = sel_lt(b) - sel_lt(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, false, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GT_LE:
-	      {
-		/* selectivity = sel_le(b) - sel_le(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, true, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GT_LT:
-	      {
-		/* selectivity = sel_lt(b) - sel_le(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, false, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_INF_LT:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_INF_LE:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GT_INF:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, true, false, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GE_INF:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, true, true, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    default:
-	      break;
-	    }
-	  if (!(success1 && success2))
-	    {
-	      if (op_type == PT_BETWEEN_INF_LT || op_type == PT_BETWEEN_INF_LE || op_type == PT_BETWEEN_GE_INF
-		  || op_type == PT_BETWEEN_GT_INF)
-		{
-		  selectivity = DEFAULT_COMP_SELECTIVITY;
-		}
-	      else
-		{
-		  selectivity = DEFAULT_BETWEEN_SELECTIVITY;
-		}
-	    }
-	}
-      else if (op_type == PT_BETWEEN_EQ_NA)
-	{
-	  /* PT_BETWEEN_EQ_NA have only one argument */
-
-	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
-
-	  if (pc1 == PC_ATTR)
-	    {
-	      /* attr1 range (attr2 = ) */
-	      rhs_icard = qo_index_cardinality (env, arg1);
-
-	      icard = MAX (lhs_icard, rhs_icard);
-	      if (icard != 0)
-		{
-		  selectivity = (1.0 / icard);
-		}
-	      else
-		{
-		  selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
-		}
-	    }
-	  else
-	    {
-	      bool success = false;
-
-	      histogram_get_equal_selectivity (lhs, arg1_db_value, &selectivity, &success);
-
-	      if (!success)
-		{
-		  /* attr1 range (const = ) */
-		  if (lhs_icard != 0)
-		    {
-		      selectivity = (1.0 / lhs_icard);
-		    }
-		  else
-		    {
-		      selectivity = DEFAULT_EQUAL_SELECTIVITY;
-		    }
-		}
-	    }
-	}
-
-
-      selectivity = MAX (selectivity, 0.0);
-      selectivity = MIN (selectivity, 1.0);
-
-      total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);
-      total_selectivity = MAX (total_selectivity, 0.0);
-      total_selectivity = MIN (total_selectivity, 1.0);
-    }
-
-  return total_selectivity;
-}
-
-/*
- * qo_all_some_in_selectivity () - Compute the selectivity of an in predicate
- *   return: double
- *   env(in): Pointer to an environment structure
- *   pt_expr(in): in expression
- *
- * Note: This uses the System R algorithm
- */
-static double
-qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PRED_CLASS pc_lhs, pc_rhs;
-  double list_card = 0.0, icard = 0.0;
-  double equal_selectivity = 1.0;
-  PT_NODE *lhs;
-  PT_NODE *arg1, *arg2;
-
-  /* To avoid repeated dereferencing */
-  arg1 = pt_expr->info.expr.arg1;
-  arg2 = pt_expr->info.expr.arg2;
-
-  /* determine the class of each side of the range */
-  pc_lhs = qo_classify (arg1);
-  pc_rhs = qo_classify (arg2);
-
-  /* The only interesting cases are: attr IN set or (attr,attr) IN set or attr IN subquery */
-  if ((pc_lhs == PC_MULTI_ATTR || pc_lhs == PC_ATTR) && (pc_rhs == PC_SET || pc_rhs == PC_SUBQUERY))
-    {
-      if (pc_lhs == PC_MULTI_ATTR)
-	{
-	  for (lhs = arg1->info.function.arg_list; lhs; lhs = lhs->next)
-	    {
-	      /* get index cardinality */
-	      icard = qo_index_cardinality (env, lhs);
-	      if (icard > 0.0)
-		{
-		  equal_selectivity *= (1.0 / icard);
-		}
-	      else
-		{
-		  /* If no index, multiply by default selectivity for each attribute */
-		  equal_selectivity *= DEFAULT_EQUAL_SELECTIVITY;
-		}
-	    }
-	}
-      else if (pc_lhs == PC_ATTR)
-	{
-	  /* check for index on the attribute.  */
-	  icard = qo_index_cardinality (env, arg1);
-	  if (icard > 0.0)
-	    {
-	      equal_selectivity *= (1.0 / icard);
-	    }
-	  else
-	    {
-	      equal_selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	    }
-	}
-
-      /* determine cardinality of set or subquery */
-      if (pc_rhs == PC_SET)
-	{
-	  if (pt_is_function (arg2))
-	    {
-	      list_card = pt_length_of_list (arg2->info.function.arg_list);
-	    }
-	  else
-	    {
-	      list_card = pt_length_of_list (arg2->info.value.data_value.set);
-	    }
-	}
-      else if (pc_rhs == PC_SUBQUERY)
-	{
-	  if (arg2->info.query.xasl)
-	    {
-	      list_card = ((XASL_NODE *) arg2->info.query.xasl)->cardinality;
-	    }
-	  else
-	    {
-	      /* legacy default list_card is 1000. Maybe it won't come in here */
-	      list_card = 1000.0;
-	    }
-	}
-
-      /* compute selectivity--cap at 0.5 */
-      double in_selectivity = list_card * equal_selectivity;
-      return in_selectivity > 0.5 ? 0.5 : in_selectivity;
-    }
-
-  return DEFAULT_IN_SELECTIVITY;
-}
-
-/*
- * qo_classify () - Determine which predicate class the node belongs in
- *   return: PRED_CLASS
- *   attr(in): pt node to classify
- */
-PRED_CLASS
-qo_classify (PT_NODE * attr)
-{
-  switch (attr->node_type)
-    {
-    case PT_NAME:
-    case PT_DOT_:
-      return PC_ATTR;
-
-    case PT_VALUE:
-      if (PT_IS_SET_TYPE (attr))
-	{
-	  return PC_SET;
-	}
-      else if (attr->type_enum == PT_TYPE_NULL)
-	{
-	  return PC_OTHER;
-	}
-      else
-	{
-	  return PC_CONST;
-	}
-
-    case PT_HOST_VAR:
-      return PC_HOST_VAR;
-
-    case PT_SELECT:
-    case PT_UNION:
-    case PT_INTERSECTION:
-    case PT_DIFFERENCE:
-      return PC_SUBQUERY;
-
-    case PT_FUNCTION:
-      /* (attr,attr) or (?,?) */
-      if (PT_IS_SET_TYPE (attr))
-	{
-	  PT_NODE *func_arg;
-	  func_arg = attr->info.function.arg_list;
-	  for ( /* none */ ; func_arg; func_arg = func_arg->next)
-	    {
-	      if (func_arg->node_type == PT_NAME)
-		{
-		  /* none */
-		}
-	      else if (func_arg->node_type == PT_HOST_VAR)
-		{
-		  return PC_SET;
-		}
-	      else
-		{
-		  return PC_OTHER;
-		}
-	    }
-	  return PC_MULTI_ATTR;
-	}
-      else
-	{
-	  return PC_OTHER;
-	}
-
-    case PT_EXPR:
-      if (pt_is_function_index_expression (attr))
-	{
-	  return PC_ATTR;
-	}
-      [[fallthrough]];
-    default:
-      return PC_OTHER;
-    }
-}
-
-/*
  * qo_index_cardinality () - Determine if the attribute has an index
  *   return: cardinality of the index if the index exists, otherwise return 0
  *   env(in): optimizer environment
  *   attr(in): pt node for the attribute for which we want the index cardinality
  */
-static int
+int
 qo_index_cardinality (QO_ENV * env, PT_NODE * attr)
 {
   PT_NODE *dummy;
@@ -10925,6 +10121,76 @@ qo_index_cardinality (QO_ENV * env, PT_NODE * attr)
 
   /* return number of the first partial-key of the index on the attribute shown in the expression */
   return info->cum_stats.pkeys[0];
+}
+
+/*
+ * qo_unique_index_cardinality () - Return class cardinality when attr is the
+ * only column of a normal unique-family index; otherwise 0.
+ */
+static int
+qo_unique_index_cardinality (QO_ENV * env, PT_NODE * attr)
+{
+  PT_NODE *dummy;
+  QO_NODE *nodep;
+  QO_SEGMENT *segp;
+  const char *attr_name;
+  int i;
+
+  if (attr->node_type == PT_DOT_)
+    {
+      attr = attr->info.dot.arg2;
+    }
+
+  QO_ASSERT (env, (attr->node_type == PT_NAME || pt_is_function_index_expression (attr)));
+
+  nodep = lookup_node (attr, env, &dummy);
+  if (nodep == NULL)
+    {
+      return 0;
+    }
+
+  segp = lookup_seg (nodep, attr, env);
+  if (segp == NULL || attr->info.name.meta_class == PT_RESERVED)
+    {
+      return 0;
+    }
+  attr_name = QO_SEG_NAME (segp);
+
+  if (QO_NODE_INFO (nodep) == NULL)
+    {
+      return 0;
+    }
+
+  for (i = 0; i < QO_NODE_INFO_N (nodep); i++)
+    {
+      QO_CLASS_INFO_ENTRY *class_info_entryp = &QO_NODE_INFO (nodep)->info[i];
+      SM_CLASS_CONSTRAINT *constraint;
+
+      if (class_info_entryp->smclass == NULL)
+	{
+	  continue;
+	}
+
+      for (constraint = class_info_entryp->smclass->constraints; constraint != NULL; constraint = constraint->next)
+	{
+	  int attr_id;
+
+	  if (constraint->index_status != SM_NORMAL_INDEX || !SM_IS_CONSTRAINT_UNIQUE_FAMILY (constraint->type)
+	      || constraint->attributes == NULL || constraint->attributes[0] == NULL
+	      || constraint->attributes[1] != NULL)
+	    {
+	      continue;
+	    }
+
+	  attr_id = sm_att_id (class_info_entryp->mop, attr_name);
+	  if (attr_id >= 0 && constraint->attributes[0]->id == attr_id)
+	    {
+	      return (QO_NODE_NCARD (nodep) > INT_MAX) ? INT_MAX : (int) QO_NODE_NCARD (nodep);
+	    }
+	}
+    }
+
+  return 0;
 }
 
 /*
@@ -11449,6 +10715,126 @@ qo_get_col_product_ndv (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int 
     }
 
   return tree;
+}
+
+static double
+qo_get_term_cost_weight (QO_TERM * term)
+{
+  PT_NODE *expr;
+  PT_NODE *node;
+  double total_weight = 0.0;
+
+  if (term == NULL)
+    {
+      return QO_COST_WEIGHT_PRED_DEFAULT;
+    }
+
+  expr = QO_TERM_PT_EXPR (term);
+  if (expr == NULL || expr->node_type != PT_EXPR)
+    {
+      return QO_COST_WEIGHT_PRED_DEFAULT;
+    }
+
+  for (node = expr; node != NULL; node = node->or_next)
+    {
+      double weight = QO_COST_WEIGHT_PRED_DEFAULT;
+
+      if (node->node_type != PT_EXPR)
+	{
+	  continue;
+	}
+
+      switch (node->info.expr.op)
+	{
+	case PT_EQ:
+	case PT_NE:
+	  {
+	    PT_NODE *lhs = node->info.expr.arg1;
+
+	    if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	      {
+		weight = QO_COST_WEIGHT_STRING_EQUAL;
+	      }
+	    else
+	      {
+		weight = QO_COST_WEIGHT_NUMERIC_COMPARE;
+	      }
+	    break;
+	  }
+
+	case PT_LT:
+	case PT_LE:
+	case PT_GT:
+	case PT_GE:
+	  {
+	    PT_NODE *lhs = node->info.expr.arg1;
+	    if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	      {
+		weight = QO_COST_WEIGHT_STRING_RANGE;
+	      }
+	    else
+	      {
+		weight = QO_COST_WEIGHT_NUMERIC_COMPARE;
+	      }
+	    break;
+	  }
+
+	case PT_LIKE:
+	case PT_NOT_LIKE:
+	  {
+	    PT_NODE *rhs = node->info.expr.arg2;
+
+	    if (rhs != NULL && rhs->node_type == PT_VALUE)
+	      {
+		const char *pat = db_get_string (&rhs->info.value.db_value);
+		if (pat != NULL)
+		  {
+		    const char *pct = strchr (pat, '%');
+		    const char *und = strchr (pat, '_');
+
+		    if (pct != NULL && pct[1] == '\0' && und == NULL && pct != pat)
+		      {
+			weight = QO_COST_WEIGHT_LIKE_PREFIX;
+		      }
+		    else if (pat[0] == '%' || und != NULL)
+		      {
+			weight = QO_COST_WEIGHT_LIKE_CONTAINS;
+		      }
+		    else
+		      {
+			weight = QO_COST_WEIGHT_LIKE_COMPLEX;
+		      }
+		  }
+		else
+		  {
+		    weight = QO_COST_WEIGHT_LIKE_COMPLEX;
+		  }
+	      }
+	    else
+	      {
+		weight = QO_COST_WEIGHT_LIKE_COMPLEX;
+	      }
+	    break;
+	  }
+
+	case PT_LIKE_ESCAPE:
+	  weight = QO_COST_WEIGHT_LIKE_COMPLEX;
+	  break;
+
+	default:
+	  weight = QO_COST_WEIGHT_PRED_DEFAULT;
+	  break;
+	}
+
+      total_weight += weight;
+    }
+
+  if (total_weight <= 0.0)
+    {
+      return QO_COST_WEIGHT_PRED_DEFAULT;
+    }
+
+  return total_weight;
 }
 
 /*

--- a/src/optimizer/query_planner_constants.h
+++ b/src/optimizer/query_planner_constants.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef _QUERY_PLANNER_CONSTANTS_H_
+#define _QUERY_PLANNER_CONSTANTS_H_
+
+#define TEST_DUMP_PLAN_SCAN_COST 0
+#define TEST_DUMP_PLAN_SORT_COST 0
+#define TEST_DUMP_PLAN_JOIN_COST 0
+#define TEST_DUMP_PLAN_FOLLOW_COST 0
+
+#define TEST_HASH_JOIN_ENABLE 0
+#define TEST_HASH_JOIN_FORCE_ENABLE 0
+
+#define INDENT_INCR		4
+#define INDENT_FMT		"%*c"
+#define TITLE_WIDTH		7
+#define TITLE_FMT		"%-" __STR(TITLE_WIDTH) "s"
+#define INDENTED_TITLE_FMT	INDENT_FMT TITLE_FMT
+#define __STR(n)		__VAL(n)
+#define __VAL(n)		#n
+#define SORT_SPEC_FMT(spec)   "%d %s %s", (spec)->pos_descr.pos_no + 1,   ((spec)->s_order == S_ASC ? "asc" : "desc"),   ((spec)->s_nulls == S_NULLS_FIRST ? "nulls first" : "nulls last")
+
+#define TEMP_SETUP_COST 5.0
+#define QO_CPU_WEIGHT 0.0025
+#define ISCAN_OID_ACCESS_OVERHEAD 20	/* need to be adjusted */
+#define MJ_CPU_OVERHEAD_FACTOR 20
+#define HJ_BUILD_CPU_OVERHEAD_FACTOR 30
+#define HJ_PROBE_CPU_OVERHEAD_FACTOR 20
+#define HJ_FILE_IO_WEIGHT 0.5	/* Unused */
+#define ISCAN_IO_HIT_RATIO 0.5
+#define QO_NLJOIN_MEMOIZE_HIT_COST_RATIO 0.01
+#define SSCAN_DEFAULT_CARD 100
+#define GUESSED_BIND_LIMIT_CARD 2000	/* When limit is a bind variable, assume that fewer rows will be assigned. */
+
+#define RBO_CHECK_COST 50
+#define RBO_CHECK_RATIO 1.2
+#define RBO_CHECK_LIMIT_RATIO 10
+
+/* generic predicate evaluation */
+#define QO_COST_WEIGHT_PRED_DEFAULT            1.00
+
+/* numeric/date equality or simple scalar comparison */
+#define QO_COST_WEIGHT_NUMERIC_COMPARE         1.00
+#define QO_COST_WEIGHT_TEMPORAL_COMPARE        1.05
+
+/* string comparisons */
+#define QO_COST_WEIGHT_STRING_EQUAL            3.00
+#define QO_COST_WEIGHT_STRING_RANGE            3.25
+#define QO_COST_WEIGHT_STRING_COLLATION        3.50
+
+/* LIKE family */
+#define QO_COST_WEIGHT_LIKE_PREFIX             3.50	/* e.g. 'abc%' */
+#define QO_COST_WEIGHT_LIKE_CONTAINS           10.00	/* e.g. '%abc%' */
+#define QO_COST_WEIGHT_LIKE_COMPLEX            14.00	/* mixed %, _, escapes */
+
+/* joins */
+#define QO_COST_WEIGHT_JOIN_DEFAULT            1.00
+#define QO_COST_WEIGHT_JOIN_STRING_EQUAL       1.10
+#define QO_COST_WEIGHT_JOIN_STRING_RANGE       1.25
+
+/* optional guard rails */
+#define QO_COST_WEIGHT_MIN                     0.50
+#define QO_COST_WEIGHT_MAX                     5.00
+
+/* sequential scan */
+#define QO_SSCAN_FILTER_CPU_FACTOR             1.00
+
+#define DEFAULT_NULL_SELECTIVITY (double) 0.01
+#define DEFAULT_EXISTS_SELECTIVITY (double) 0.1
+#define DEFAULT_SELECTIVITY (double) 0.1
+#define DEFAULT_EQUAL_SELECTIVITY (double) 0.001
+#define DEFAULT_EQUIJOIN_SELECTIVITY (double) 0.001
+#define DEFAULT_COMP_SELECTIVITY (double) 0.1
+#define DEFAULT_BETWEEN_SELECTIVITY (double) 0.01
+#define DEFAULT_IN_SELECTIVITY (double) 0.01
+#define DEFAULT_RANGE_SELECTIVITY (double) 0.1
+
+#endif /* _QUERY_PLANNER_CONSTANTS_H_ */

--- a/src/optimizer/query_planner_internal.h
+++ b/src/optimizer/query_planner_internal.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef _QUERY_PLANNER_INTERNAL_H_
+#define _QUERY_PLANNER_INTERNAL_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <assert.h>
+#if !defined(WINDOWS)
+#include <values.h>
+#endif /* !WINDOWS */
+#include "jansson.h"
+
+#include "parser.h"
+#include "object_primitive.h"
+#include "optimizer.h"
+#include "query_planner.h"
+#include "query_graph.h"
+#include "environment_variable.h"
+#include "misc_string.h"
+#include "system_parameter.h"
+#include "parser.h"
+#include "parser_message.h"
+#include "intl_support.h"
+#include "storage_common.h"
+#include "xasl_analytic.hpp"
+#include "xasl_generation.h"
+#include "schema_manager.h"
+#include "network_interface_cl.h"
+#include "dbtype.h"
+#include "regu_var.hpp"
+#include "histogram_cl.hpp"
+#include "query_planner_constants.h"
+
+double qo_or_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel);
+double qo_and_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel);
+double qo_not_selectivity (QO_ENV * env, double sel);
+double qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+double qo_comp_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+double qo_between_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+double qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+double qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+double qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+int qo_index_cardinality (QO_ENV * env, PT_NODE * attr);
+
+#endif /* _QUERY_PLANNER_INTERNAL_H_ */

--- a/src/optimizer/query_planner_selectivity.c
+++ b/src/optimizer/query_planner_selectivity.c
@@ -1,0 +1,1110 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ident "$Id$"
+
+#include "config.h"
+#include "query_planner_internal.h"
+#include "query_planner_constants.h"
+
+double
+qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  double lhs_selectivity, rhs_selectivity, selectivity, total_selectivity;
+  PT_NODE *node;
+  bool not_null_calculated = false;
+
+  QO_ASSERT (env, pt_expr != NULL);
+  QO_ASSERT (env, pt_expr->node_type == PT_EXPR);
+
+  selectivity = 0.0;
+  total_selectivity = 0.0;
+
+  /* traverse OR list */
+  for (node = pt_expr; node; node = node->or_next)
+    {
+      switch (node->info.expr.op)
+	{
+	case PT_OR:
+	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
+	  rhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg2);
+	  selectivity = qo_or_selectivity (env, lhs_selectivity, rhs_selectivity);
+	  break;
+
+	case PT_AND:
+	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
+	  rhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg2);
+	  selectivity = qo_and_selectivity (env, lhs_selectivity, rhs_selectivity);
+	  break;
+
+	case PT_NOT:
+	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
+	  selectivity = qo_not_selectivity (env, lhs_selectivity);
+	  break;
+
+	case PT_EQ:
+	  selectivity = qo_equal_selectivity (env, node);
+	  break;
+
+	case PT_NE:
+	  lhs_selectivity = qo_equal_selectivity (env, node);
+	  selectivity = qo_not_selectivity (env, lhs_selectivity);
+	  break;
+
+	case PT_NULLSAFE_EQ:
+	  selectivity = qo_equal_selectivity (env, node);
+	  break;
+
+	case PT_GE:
+	case PT_GT:
+	case PT_LT:
+	case PT_LE:
+	  selectivity = qo_comp_selectivity (env, node);
+	  break;
+
+	case PT_BETWEEN:
+	  selectivity = qo_between_selectivity (env, node);
+	  break;
+
+	case PT_NOT_BETWEEN:
+	  lhs_selectivity = qo_between_selectivity (env, node);
+	  selectivity = qo_not_selectivity (env, lhs_selectivity);
+	  break;
+
+	case PT_RANGE:
+	  selectivity = qo_range_selectivity (env, node);
+	  break;
+
+	case PT_LIKE_ESCAPE:
+	  selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+	  break;
+	case PT_LIKE:
+	  {
+	    selectivity = qo_like_selectivity (env, node);
+	    break;
+	  }
+	case PT_NOT_LIKE:
+	  {
+	    selectivity = 1 - qo_like_selectivity (env, node);
+	    break;
+	  }
+	case PT_SETNEQ:
+	case PT_SETEQ:
+	case PT_SUPERSETEQ:
+	case PT_SUPERSET:
+	case PT_SUBSET:
+	case PT_SUBSETEQ:
+	case PT_IS:
+	case PT_XOR:
+	  selectivity = DEFAULT_SELECTIVITY;
+	  break;
+
+	case PT_IS_NOT:
+	  selectivity = qo_not_selectivity (env, DEFAULT_SELECTIVITY);
+	  break;
+
+	case PT_EQ_SOME:
+	case PT_NE_SOME:
+	case PT_GE_SOME:
+	case PT_GT_SOME:
+	case PT_LT_SOME:
+	case PT_LE_SOME:
+	case PT_EQ_ALL:
+	case PT_NE_ALL:
+	case PT_GE_ALL:
+	case PT_GT_ALL:
+	case PT_LT_ALL:
+	case PT_LE_ALL:
+	case PT_IS_IN:
+	  selectivity = qo_all_some_in_selectivity (env, node);
+	  break;
+
+	case PT_IS_NOT_IN:
+	  lhs_selectivity = qo_all_some_in_selectivity (env, node);
+	  selectivity = qo_not_selectivity (env, lhs_selectivity);
+	  break;
+
+	case PT_IS_NULL:
+	  if (pt_expr->info.expr.arg1->node_type == PT_NAME && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
+	    {
+	      selectivity = pt_expr->info.expr.arg1->info.name.null_frequency;
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_NULL_SELECTIVITY;
+	    }
+	  not_null_calculated = true;
+	  break;
+
+	case PT_IS_NOT_NULL:
+	  if (pt_expr->info.expr.arg1->node_type == PT_NAME && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
+	    {
+	      selectivity = pt_expr->info.expr.arg1->info.name.null_frequency;
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_NULL_SELECTIVITY;
+	    }
+	  selectivity = 1 - selectivity;
+	  not_null_calculated = true;
+	  break;
+
+	case PT_EXISTS:
+	  selectivity = DEFAULT_EXISTS_SELECTIVITY;	/* make a guess */
+	  break;
+
+	default:
+	  break;
+	}
+
+      if (!not_null_calculated)
+	{
+	  if (pt_expr->info.expr.arg1 && pt_expr->info.expr.arg1->node_type == PT_NAME
+	      && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
+	    {
+	      selectivity = selectivity * (1 - pt_expr->info.expr.arg1->info.name.null_frequency);
+	    }
+	  if (pt_expr->info.expr.arg2 && pt_expr->info.expr.arg2->node_type == PT_NAME
+	      && pt_expr->info.expr.arg2->info.name.null_frequency >= 0.0)
+	    {
+	      selectivity = selectivity * (1 - pt_expr->info.expr.arg2->info.name.null_frequency);
+	    }
+	}
+
+      total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);
+      total_selectivity = MAX (total_selectivity, 0.0);
+      total_selectivity = MIN (total_selectivity, 1.0);
+    }
+
+  return total_selectivity;
+}
+
+double
+qo_or_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel)
+{
+  double result;
+
+  QO_ASSERT (env, lhs_sel >= 0.0);
+  QO_ASSERT (env, lhs_sel <= 1.0);
+  QO_ASSERT (env, rhs_sel >= 0.0);
+  QO_ASSERT (env, rhs_sel <= 1.0);
+
+  result = lhs_sel + rhs_sel - (lhs_sel * rhs_sel);
+
+  return result;
+}
+
+double
+qo_and_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel)
+{
+  double result;
+
+  QO_ASSERT (env, lhs_sel >= 0.0);
+  QO_ASSERT (env, lhs_sel <= 1.0);
+  QO_ASSERT (env, rhs_sel >= 0.0);
+  QO_ASSERT (env, rhs_sel <= 1.0);
+
+  result = lhs_sel * rhs_sel;
+
+  return result;
+}
+
+double
+qo_not_selectivity (QO_ENV * env, double sel)
+{
+  QO_ASSERT (env, sel >= 0.0);
+  QO_ASSERT (env, sel <= 1.0);
+
+  return 1.0 - sel;
+}
+
+double
+qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  PT_NODE *lhs, *rhs, *multi_attr;
+  DB_VALUE *host_var;
+  PRED_CLASS pc_lhs, pc_rhs;
+  int lhs_icard, rhs_icard, icard;
+  double selectivity;
+
+  lhs = pt_expr->info.expr.arg1;
+  rhs = pt_expr->info.expr.arg2;
+
+  /* the class of lhs and rhs */
+  pc_lhs = qo_classify (lhs);
+  pc_rhs = qo_classify (rhs);
+
+  selectivity = DEFAULT_EQUAL_SELECTIVITY;
+
+  bool success = false;
+
+  switch (pc_lhs)
+    {
+    case PC_ATTR:
+
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  {
+	    /* attr = attr */
+	    bool success = false;
+	    double eqjoin_selectivity = 0.0;
+	    histogram_get_eqjoin_selectivity (lhs, rhs, &eqjoin_selectivity, &success);
+	    if (success)
+	      {
+		selectivity = eqjoin_selectivity;
+	      }
+	    else
+	      {
+
+		/* check for indexes on either of the attributes */
+		lhs_icard = qo_index_cardinality (env, lhs);
+		rhs_icard = qo_index_cardinality (env, rhs);
+
+		icard = MAX (lhs_icard, rhs_icard);
+		if (icard != 0)
+		  {
+		    selectivity = (1.0 / icard);
+		  }
+		else
+		  {
+		    selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
+		  }
+	      }
+	  }
+	  break;
+
+	case PC_CONST:
+	case PC_HOST_VAR:
+	  if (pc_rhs == PC_HOST_VAR)
+	    {
+	      host_var = &env->parser->host_variables[rhs->info.host_var.index];
+	    }
+	  else
+	    {
+	      host_var = &rhs->info.value.db_value;
+	    }
+	  histogram_get_equal_selectivity (lhs, host_var, &selectivity, &success);
+	  if (success)
+	    {
+	      break;
+	    }
+	  [[fallthrough]];
+
+	case PC_SUBQUERY:
+	case PC_SET:
+	case PC_OTHER:
+	  /* attr = const */
+
+	  /* check for index on the attribute.  NOTE: For an equality predicate, we treat subqueries as constants. */
+	  lhs_icard = qo_index_cardinality (env, lhs);
+	  if (lhs_icard != 0)
+	    {
+	      selectivity = (1.0 / lhs_icard);
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	    }
+
+	  break;
+
+	case PC_MULTI_ATTR:
+	  /* attr = (attr,attr) syntactic impossible case */
+	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	  break;
+	}
+
+      break;
+
+    case PC_CONST:
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  histogram_get_equal_selectivity (rhs, &lhs->info.value.db_value, &selectivity, &success);
+	  break;
+
+	default:
+	  break;
+	}
+      if (success)
+	{
+	  break;
+	}
+      [[fallthrough]];
+
+    case PC_HOST_VAR:
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  host_var = &env->parser->host_variables[lhs->info.host_var.index];
+	  histogram_get_equal_selectivity (rhs, host_var, &selectivity, &success);
+	  break;
+
+	default:
+	  break;
+	}
+      if (success)
+	{
+	  break;
+	}
+      [[fallthrough]];
+    case PC_SUBQUERY:
+    case PC_SET:
+    case PC_OTHER:
+
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  /* const = attr */
+
+	  /* check for index on the attribute.  NOTE: For an equality predicate, we treat subqueries as constants. */
+	  rhs_icard = qo_index_cardinality (env, rhs);
+	  if (rhs_icard != 0)
+	    {
+	      selectivity = (1.0 / rhs_icard);
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	    }
+
+	  break;
+
+	case PC_CONST:
+	case PC_HOST_VAR:
+	case PC_SUBQUERY:
+	case PC_SET:
+	case PC_OTHER:
+	  /* const = const */
+
+	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	  break;
+
+	case PC_MULTI_ATTR:
+	  /* const = (attr,attr) */
+	  multi_attr = rhs->info.function.arg_list;
+	  rhs_icard = 0;
+	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
+	    {
+	      /* get index cardinality */
+	      icard = qo_index_cardinality (env, multi_attr);
+	      if (icard <= 0)
+		{
+		  /* the only interesting case is PT_BETWEEN_EQ_NA */
+		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
+		}
+	      if (rhs_icard == 0)
+		{
+		  /* first time */
+		  rhs_icard = icard;
+		}
+	      else
+		{
+		  rhs_icard *= icard;
+		}
+	    }
+	  if (rhs_icard != 0)
+	    {
+	      selectivity = (1.0 / rhs_icard);
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	    }
+	  break;
+	}
+      break;
+
+    case PC_MULTI_ATTR:
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  /* (attr,attr) = attr  syntactic impossible case */
+	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	  break;
+
+	case PC_CONST:
+	case PC_HOST_VAR:
+	case PC_SUBQUERY:
+	case PC_SET:
+	case PC_OTHER:
+	  /* (attr,attr) = const */
+
+	  multi_attr = lhs->info.function.arg_list;
+	  lhs_icard = 0;
+	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
+	    {
+	      /* get index cardinality */
+	      icard = qo_index_cardinality (env, multi_attr);
+	      if (icard <= 0)
+		{
+		  /* the only interesting case is PT_BETWEEN_EQ_NA */
+		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
+		}
+	      if (lhs_icard == 0)
+		{
+		  /* first time */
+		  lhs_icard = icard;
+		}
+	      else
+		{
+		  lhs_icard *= icard;
+		}
+	    }
+	  if (lhs_icard != 0)
+	    {
+	      selectivity = (1.0 / lhs_icard);
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	    }
+	  break;
+
+	case PC_MULTI_ATTR:
+	  /* (attr,attr) = (attr,attr) */
+	  multi_attr = lhs->info.function.arg_list;
+	  lhs_icard = 0;
+	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
+	    {
+	      /* get index cardinality */
+	      icard = qo_index_cardinality (env, multi_attr);
+	      if (icard <= 0)
+		{
+		  /* the only interesting case is PT_BETWEEN_EQ_NA */
+		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
+		}
+	      if (lhs_icard == 0)
+		{
+		  /* first time */
+		  lhs_icard = icard;
+		}
+	      else
+		{
+		  lhs_icard *= icard;
+		}
+	    }
+
+	  multi_attr = rhs->info.function.arg_list;
+	  rhs_icard = 0;
+	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
+	    {
+	      /* get index cardinality */
+	      icard = qo_index_cardinality (env, multi_attr);
+	      if (icard <= 0)
+		{
+		  /* the only interesting case is PT_BETWEEN_EQ_NA */
+		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
+		}
+	      if (rhs_icard == 0)
+		{
+		  /* first time */
+		  rhs_icard = icard;
+		}
+	      else
+		{
+		  rhs_icard *= icard;
+		}
+	    }
+
+	  icard = MAX (lhs_icard, rhs_icard);
+	  if (icard != 0)
+	    {
+	      selectivity = (1.0 / icard);
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
+	    }
+	  break;
+	}
+
+      break;
+      break;
+    }
+
+  return selectivity;
+}
+
+double
+qo_comp_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  PT_NODE *lhs, *rhs, *multi_attr;
+  PRED_CLASS pc_lhs, pc_rhs;
+  DB_VALUE *rhs_db_value;
+  DB_VALUE *lhs_db_value;
+  int lhs_icard, rhs_icard, icard;
+  double selectivity;
+
+  lhs = pt_expr->info.expr.arg1;
+  rhs = pt_expr->info.expr.arg2;
+
+  /* the class of lhs and rhs */
+  pc_lhs = qo_classify (lhs);
+  pc_rhs = qo_classify (rhs);
+
+  selectivity = DEFAULT_COMP_SELECTIVITY;
+
+  bool success = false;
+  switch (pc_lhs)
+    {
+    case PC_ATTR:
+
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  /* TODO: add histogram selectivity */
+	  break;
+
+	case PC_CONST:
+	case PC_HOST_VAR:
+	  {
+	    if (pc_rhs == PC_HOST_VAR)
+	      {
+		rhs_db_value = &env->parser->host_variables[rhs->info.host_var.index];
+	      }
+	    else
+	      {
+		rhs_db_value = &rhs->info.value.db_value;
+	      }
+
+	    if (pt_expr->info.expr.op == PT_GE)
+	      {
+		histogram_get_comp_selectivity (lhs, rhs_db_value, true, true, &selectivity, &success);
+	      }
+	    else if (pt_expr->info.expr.op == PT_GT)
+	      {
+		histogram_get_comp_selectivity (lhs, rhs_db_value, true, false, &selectivity, &success);
+	      }
+	    else if (pt_expr->info.expr.op == PT_LE)
+	      {
+		histogram_get_comp_selectivity (lhs, rhs_db_value, false, true, &selectivity, &success);
+	      }
+	    else if (pt_expr->info.expr.op == PT_LT)
+	      {
+		histogram_get_comp_selectivity (lhs, rhs_db_value, false, false, &selectivity, &success);
+	      }
+	  }
+	  break;
+
+	default:
+	  break;
+	}
+
+      break;
+
+    case PC_CONST:
+    case PC_HOST_VAR:
+      {
+	switch (pc_rhs)
+	  {
+	  case PC_ATTR:
+	    {
+	      if (pc_lhs == PC_HOST_VAR)
+		{
+		  lhs_db_value = &env->parser->host_variables[lhs->info.host_var.index];
+		}
+	      else
+		{
+		  lhs_db_value = &lhs->info.value.db_value;
+		}
+	      if (pt_expr->info.expr.op == PT_GE)
+		{
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, false, &selectivity, &success);
+		}
+	      else if (pt_expr->info.expr.op == PT_GT)
+		{
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, true, &selectivity, &success);
+		}
+	      else if (pt_expr->info.expr.op == PT_LE)
+		{
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, false, &selectivity, &success);
+		}
+	      else if (pt_expr->info.expr.op == PT_LT)
+		{
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, true, &selectivity, &success);
+		}
+	      break;
+	    }
+	  default:
+	    break;
+	  }
+      }
+      break;
+
+    case PC_MULTI_ATTR:
+      switch (pc_rhs)
+	{
+	case PC_MULTI_ATTR:
+	  /* (attr,attr) = (attr,attr) */
+	  /* TODO: add histogram selectivity */
+	  break;
+
+	default:
+	  break;
+	}
+
+      break;
+    default:
+      break;
+    }
+
+  return success ? selectivity : DEFAULT_COMP_SELECTIVITY;
+}
+
+double
+qo_between_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  PT_NODE *and_node;
+
+  and_node = pt_expr->info.expr.arg2;
+
+  QO_ASSERT (env, and_node->node_type == PT_EXPR);
+  QO_ASSERT (env, pt_is_between_range_op (and_node->info.expr.op));
+
+  return DEFAULT_BETWEEN_SELECTIVITY;
+}
+
+double
+qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  PT_NODE *lhs, *arg1, *arg2;
+  DB_VALUE *lhs_db_value;
+  DB_VALUE *arg1_db_value;
+  DB_VALUE *arg2_db_value;
+  PRED_CLASS pc1, pc2;
+  PRED_CLASS pc_arg1, pc_arg2;
+
+  double total_selectivity;
+  double selectivity = DEFAULT_BETWEEN_SELECTIVITY;
+  int lhs_icard = 0, rhs_icard = 0, icard = 0;
+  PT_NODE *range_node;
+  PT_OP_TYPE op_type;
+
+  lhs = pt_expr->info.expr.arg1;
+
+  pc2 = qo_classify (lhs);
+
+  /* the only interesting case is 'attr RANGE {=1,=2}' or '(attr,attr) RANGE {={..},..}' */
+  if (pc2 == PC_MULTI_ATTR)
+    {
+      lhs = lhs->info.function.arg_list;
+      lhs_icard = 0;
+      for ( /* none */ ; lhs; lhs = lhs->next)
+	{
+	  /* get index cardinality */
+	  icard = qo_index_cardinality (env, lhs);
+	  if (icard <= 0)
+	    {
+	      /* the only interesting case is PT_BETWEEN_EQ_NA */
+	      icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
+	    }
+	  if (lhs_icard == 0)
+	    {
+	      /* first time */
+	      lhs_icard = icard;
+	    }
+	  else
+	    {
+	      lhs_icard *= icard;
+	    }
+	}
+    }
+  else if (pc2 == PC_ATTR)
+    {
+      /* get index cardinality */
+      lhs_icard = qo_index_cardinality (env, lhs);
+    }
+  else
+    {
+      return DEFAULT_RANGE_SELECTIVITY;
+    }
+#if 1				/* unused anymore - DO NOT DELETE ME */
+  QO_ASSERT (env, !PT_EXPR_INFO_IS_FLAGED (pt_expr, PT_EXPR_INFO_FULL_RANGE));
+#endif
+
+  total_selectivity = 0.0;
+
+  for (range_node = pt_expr->info.expr.arg2; range_node; range_node = range_node->or_next)
+    {
+      QO_ASSERT (env, range_node->node_type == PT_EXPR);
+
+      op_type = range_node->info.expr.op;
+      QO_ASSERT (env, pt_is_between_range_op (op_type));
+
+      arg1 = range_node->info.expr.arg1;
+      arg2 = range_node->info.expr.arg2;
+
+      pc_arg1 = qo_classify (arg1);
+      pc1 = pc_arg1;
+
+      if (pc_arg1 == PC_HOST_VAR)
+	{
+	  arg1_db_value = &env->parser->host_variables[arg1->info.host_var.index];
+	}
+      else if (pc_arg1 == PC_CONST)
+	{
+	  arg1_db_value = &arg1->info.value.db_value;
+	}
+      else
+	{
+	  arg1_db_value = NULL;
+	}
+
+      if (arg2 != NULL)
+	{
+	  pc_arg2 = qo_classify (arg2);
+
+	  if (pc_arg2 == PC_HOST_VAR)
+	    {
+	      arg2_db_value = &env->parser->host_variables[arg2->info.host_var.index];
+	    }
+	  else if (pc_arg2 == PC_CONST)
+	    {
+	      arg2_db_value = &arg2->info.value.db_value;
+	    }
+	  else
+	    {
+	      arg2_db_value = NULL;
+	    }
+	}
+      else
+	{
+	  arg2_db_value = NULL;
+	}
+
+      if (op_type == PT_BETWEEN_GE_LE || op_type == PT_BETWEEN_GE_LT || op_type == PT_BETWEEN_GT_LE
+	  || op_type == PT_BETWEEN_GT_LT || op_type == PT_BETWEEN_INF_LT || op_type == PT_BETWEEN_INF_LE
+	  || op_type == PT_BETWEEN_GE_INF || op_type == PT_BETWEEN_GT_INF)
+	{
+	  double selectivity_a = 0.0, selectivity_b = 0.0, selectivity_backup = selectivity;
+	  bool success1 = false;
+	  bool success2 = false;
+	  bool success3 = false;
+	  switch (op_type)
+	    {
+	    case PT_BETWEEN_GE_LE:
+	      {
+		/* selectivity = sel_le(b) - sel_lt(a) */
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
+		histogram_get_comp_selectivity (lhs, arg2_db_value, false, true, &selectivity_b, &success2);
+		selectivity = selectivity_b - selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_GE_LT:
+	      {
+		/* selectivity = sel_lt(b) - sel_lt(a) */
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
+		histogram_get_comp_selectivity (lhs, arg2_db_value, false, false, &selectivity_b, &success2);
+		selectivity = selectivity_b - selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_GT_LE:
+	      {
+		/* selectivity = sel_le(b) - sel_le(a) */
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
+		histogram_get_comp_selectivity (lhs, arg2_db_value, false, true, &selectivity_b, &success2);
+		selectivity = selectivity_b - selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_GT_LT:
+	      {
+		/* selectivity = sel_lt(b) - sel_le(a) */
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
+		histogram_get_comp_selectivity (lhs, arg2_db_value, false, false, &selectivity_b, &success2);
+		selectivity = selectivity_b - selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_INF_LT:
+	      {
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
+		success2 = true;
+		selectivity = selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_INF_LE:
+	      {
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
+		success2 = true;
+		selectivity = selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_GT_INF:
+	      {
+		histogram_get_comp_selectivity (lhs, arg1_db_value, true, false, &selectivity_a, &success1);
+		success2 = true;
+		selectivity = selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_GE_INF:
+	      {
+		histogram_get_comp_selectivity (lhs, arg1_db_value, true, true, &selectivity_a, &success1);
+		success2 = true;
+		selectivity = selectivity_a;
+		break;
+	      }
+	    default:
+	      break;
+	    }
+
+	  double default_zero_selectivity = 0.0;
+	  histogram_get_default_selectivity (lhs, arg1_db_value, &default_zero_selectivity, &success3);
+
+	  if (success3)
+	    {
+	      selectivity = MAX (selectivity, default_zero_selectivity);
+	    }
+
+	  if (!(success1 && success2))
+	    {
+	      if (op_type == PT_BETWEEN_INF_LT || op_type == PT_BETWEEN_INF_LE || op_type == PT_BETWEEN_GE_INF
+		  || op_type == PT_BETWEEN_GT_INF)
+		{
+		  selectivity = DEFAULT_COMP_SELECTIVITY;
+		}
+	      else
+		{
+		  selectivity = DEFAULT_BETWEEN_SELECTIVITY;
+		}
+	    }
+	}
+      else if (op_type == PT_BETWEEN_EQ_NA)
+	{
+	  /* PT_BETWEEN_EQ_NA have only one argument */
+
+	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
+
+	  if (pc1 == PC_ATTR)
+	    {
+	      /* attr1 range (attr2 = ) */
+	      rhs_icard = qo_index_cardinality (env, arg1);
+
+	      icard = MAX (lhs_icard, rhs_icard);
+	      if (icard != 0)
+		{
+		  selectivity = (1.0 / icard);
+		}
+	      else
+		{
+		  selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
+		}
+	    }
+	  else
+	    {
+	      bool success = false;
+
+	      histogram_get_equal_selectivity (lhs, arg1_db_value, &selectivity, &success);
+
+	      if (!success)
+		{
+		  /* attr1 range (const = ) */
+		  if (lhs_icard != 0)
+		    {
+		      selectivity = (1.0 / lhs_icard);
+		    }
+		  else
+		    {
+		      selectivity = DEFAULT_EQUAL_SELECTIVITY;
+		    }
+		}
+	    }
+	}
+
+
+      selectivity = MAX (selectivity, 0.0);
+      selectivity = MIN (selectivity, 1.0);
+
+      total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);
+      total_selectivity = MAX (total_selectivity, 0.0);
+      total_selectivity = MIN (total_selectivity, 1.0);
+    }
+
+  return total_selectivity;
+}
+
+double
+qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  PRED_CLASS pc_lhs, pc_rhs;
+  double list_card = 0.0, icard = 0.0;
+  double equal_selectivity = 1.0;
+  PT_NODE *lhs;
+  PT_NODE *arg1, *arg2;
+
+  /* To avoid repeated dereferencing */
+  arg1 = pt_expr->info.expr.arg1;
+  arg2 = pt_expr->info.expr.arg2;
+
+  /* determine the class of each side of the range */
+  pc_lhs = qo_classify (arg1);
+  pc_rhs = qo_classify (arg2);
+
+  /* The only interesting cases are: attr IN set or (attr,attr) IN set or attr IN subquery */
+  if ((pc_lhs == PC_MULTI_ATTR || pc_lhs == PC_ATTR) && (pc_rhs == PC_SET || pc_rhs == PC_SUBQUERY))
+    {
+      if (pc_lhs == PC_MULTI_ATTR)
+	{
+	  for (lhs = arg1->info.function.arg_list; lhs; lhs = lhs->next)
+	    {
+	      /* get index cardinality */
+	      icard = qo_index_cardinality (env, lhs);
+	      if (icard > 0.0)
+		{
+		  equal_selectivity *= (1.0 / icard);
+		}
+	      else
+		{
+		  /* If no index, multiply by default selectivity for each attribute */
+		  equal_selectivity *= DEFAULT_EQUAL_SELECTIVITY;
+		}
+	    }
+	}
+      else if (pc_lhs == PC_ATTR)
+	{
+	  /* check for index on the attribute.  */
+	  icard = qo_index_cardinality (env, arg1);
+	  if (icard > 0.0)
+	    {
+	      equal_selectivity *= (1.0 / icard);
+	    }
+	  else
+	    {
+	      equal_selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	    }
+	}
+
+      /* determine cardinality of set or subquery */
+      if (pc_rhs == PC_SET)
+	{
+	  if (pt_is_function (arg2))
+	    {
+	      list_card = pt_length_of_list (arg2->info.function.arg_list);
+	    }
+	  else
+	    {
+	      list_card = pt_length_of_list (arg2->info.value.data_value.set);
+	    }
+	}
+      else if (pc_rhs == PC_SUBQUERY)
+	{
+	  if (arg2->info.query.xasl)
+	    {
+	      list_card = ((XASL_NODE *) arg2->info.query.xasl)->cardinality;
+	    }
+	  else
+	    {
+	      /* legacy default list_card is 1000. Maybe it won't come in here */
+	      list_card = 1000.0;
+	    }
+	}
+
+      /* compute selectivity--cap at 0.5 */
+      double in_selectivity = list_card * equal_selectivity;
+      return in_selectivity > 0.5 ? 0.5 : in_selectivity;
+    }
+
+  return DEFAULT_IN_SELECTIVITY;
+}
+
+PRED_CLASS
+qo_classify (PT_NODE * attr)
+{
+  switch (attr->node_type)
+    {
+    case PT_NAME:
+    case PT_DOT_:
+      return PC_ATTR;
+
+    case PT_VALUE:
+      if (PT_IS_SET_TYPE (attr))
+	{
+	  return PC_SET;
+	}
+      else if (attr->type_enum == PT_TYPE_NULL)
+	{
+	  return PC_OTHER;
+	}
+      else
+	{
+	  return PC_CONST;
+	}
+
+    case PT_HOST_VAR:
+      return PC_HOST_VAR;
+
+    case PT_SELECT:
+    case PT_UNION:
+    case PT_INTERSECTION:
+    case PT_DIFFERENCE:
+      return PC_SUBQUERY;
+
+    case PT_FUNCTION:
+      /* (attr,attr) or (?,?) */
+      if (PT_IS_SET_TYPE (attr))
+	{
+	  PT_NODE *func_arg;
+	  func_arg = attr->info.function.arg_list;
+	  for ( /* none */ ; func_arg; func_arg = func_arg->next)
+	    {
+	      if (func_arg->node_type == PT_NAME)
+		{
+		  /* none */
+		}
+	      else if (func_arg->node_type == PT_HOST_VAR)
+		{
+		  return PC_SET;
+		}
+	      else
+		{
+		  return PC_OTHER;
+		}
+	    }
+	  return PC_MULTI_ATTR;
+	}
+      else
+	{
+	  return PC_OTHER;
+	}
+
+    case PT_EXPR:
+      if (pt_is_function_index_expression (attr))
+	{
+	  return PC_ATTR;
+	}
+      [[fallthrough]];
+    default:
+      return PC_OTHER;
+    }
+}
+
+double
+qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  /* Base LIKE selectivity: the system parameter PRM_ID_LIKE_TERM_SELECTIVITY.
+   * Histogram/pattern-based LIKE selectivity is added in the LIKE-selectivity layer (PR L2). */
+  PT_NODE *lhs = pt_expr->info.expr.arg1;
+  PT_NODE *rhs = pt_expr->info.expr.arg2;
+
+  if (lhs == NULL || rhs == NULL)
+    {
+      return 0.0;
+    }
+
+  return (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+}

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -12304,6 +12304,7 @@ error_return:
   return error;
 }
 
+
 /*
  * do_create_midxkey_for_constraint () - create a MIDX_KEY db_value for the
  *					 specified constraint using the values


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26746>

> 히스토그램 옵티마이저 작업(CBRD-26746)을 기능 단위로 나눈 **누적 PR 1/3** 입니다.
> 스택: **PR1(본 PR)** → PR2(LIKE 선택도) → PR3(조인 카디널리티).
> base 브랜치 `hist-split-base`는 이 작업이 기준으로 삼은 develop 상태입니다.

### Purpose

기존 옵티마이저는 컬럼 데이터 분포를 반영하지 못해, 조건을 만족하는 행 비율(선택도)과 조인 결과 건수를 균일 가정으로만 추정했습니다. 분포가 치우친 컬럼이나 다중 조인에서 예측이 실제와 크게 달라 비효율적인 실행 계획이 선택될 수 있었습니다. 본 PR은 그 토대로, 컬럼 **히스토그램·MCV(자주 등장하는 값) 통계**를 활용해 선택도/카디널리티 추정 정확도를 높입니다.

### Implementation

- **선택도 모듈 분리**: 선택도 계산 로직을 `query_planner_selectivity.c`로 분리(모듈화)하고, `query_planner.c`/`query_graph.c`/`plan_generation.c`의 관련 경로와 상수를 정리했습니다.
- **히스토그램 기반 선택도**: 등호/범위 선택도를 히스토그램 분포로 추정하고, **MCV 정확매칭**(자주 등장하는 값의 빈도 직접 반영, 등가 조인 포함)과 **비-MCV 구간 NDV 폴백**을 적용했습니다. (`query_planner_selectivity.c`, `src/optimizer/histogram/histogram_cl.cpp`)
- **NULL 빈도 반영**: 등호뿐 아니라 NE(≠) 등 선택도 계산에 null 빈도를 반영했습니다.
- 통계가 없거나 적용 불가한 경우 기존 방식으로 안전하게 폴백합니다.

### Remarks

- LIKE/패턴 선택도와 조인 카디널리티 비용은 본 PR에서 제외하고 각각 후속 누적 PR(2/3, 3/3)로 분리했습니다.
- MCV·NULL 처리는 등호 선택도와 동일 함수 내부에 구현되어 분리가 불가능하여 본 PR에 함께 포함했습니다.
- 리뷰어는 작성자가 직접 지정할 예정입니다.
