### PR TITLE
[CBRD-26746] Histogram-based selectivity (L1/L2) + eqjoin/iscan NDV fixes

### DIFF
--- a/cs/CMakeLists.txt
+++ b/cs/CMakeLists.txt
@@ -245,6 +245,7 @@ set(OPTIMIZER_SOURCES
   ${OPTIMIZER_DIR}/query_bitset.c
   ${OPTIMIZER_DIR}/query_graph.c
   ${OPTIMIZER_DIR}/query_planner.c
+  ${OPTIMIZER_DIR}/query_planner_selectivity.c
   ${OPTIMIZER_DIR}/plan_generation.c
   )
 

--- a/sa/CMakeLists.txt
+++ b/sa/CMakeLists.txt
@@ -257,6 +257,7 @@ set(OPTIMIZER_SOURCES
   ${OPTIMIZER_DIR}/query_bitset.c
   ${OPTIMIZER_DIR}/query_graph.c
   ${OPTIMIZER_DIR}/query_planner.c
+  ${OPTIMIZER_DIR}/query_planner_selectivity.c
   ${OPTIMIZER_DIR}/plan_generation.c
   )
 

--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -1152,44 +1152,74 @@ histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *se
 	}
     }
 
-  /* Non-MCV buckets: fraction of bucket boundary values (bucket_hi) matching the pattern.
-   * Applies the operator to each
-   * histogram entry and counts matches. */
+  /* Non-MCV buckets: LIKE is tested only against each bucket's boundary value (bucket_hi),
+   * so a bucket's evidence weakens as its distinct-value count (approx_ndv) grows. We accumulate
+   * a per-bucket confidence (min (1, 3/approx_ndv)) to discount wide buckets later. */
   double matched_non_mcv_buckets = 0.0;
   double non_mcv_buckets = 0.0;
+  double ndv_confidence_sum = 0.0;	/* sum of confidence that bucket_hi represents its bucket */
 
   for (int i = 0; i < static_cast<int> (histogram_reader.bucket_count ()); i++)
     {
+      const int approx_ndv = histogram_reader.bucket_approx_ndv (i);
       non_mcv_buckets += 1.0;
+
+      const double bucket_confidence = std::min (1.0, 3.0 / static_cast<double> (approx_ndv > 0 ? approx_ndv : 1));
+      ndv_confidence_sum += bucket_confidence;
+
       if (like_match_string (pattern, histogram_reader.bucket_hi<std::string> (i)))
 	{
 	  matched_non_mcv_buckets += 1.0;
 	}
     }
 
-  /* char-count heuristic; used only as a fallback for small histograms */
+  /* char-count heuristic; used as a prior and a fallback for small histograms */
   const double pattern_sel = pattern_heuristic_selectivity (pattern, '\0');
   assert_release (pattern_sel >= 0.0 && pattern_sel <= 1.0);
 
-  /* the histogram value-match fraction is the primary
-   * non-MCV estimate. Trust it fully once the histogram is large enough (>=100 entries);
-   * blend with the heuristic for 10..99 entries (weight = size/100); below 10 use the
-   * heuristic alone. */
-  double total_non_mcv_sel;
-  const int hist_size = static_cast<int> (non_mcv_buckets);
-  if (hist_size >= 100)
-    {
-      total_non_mcv_sel = matched_non_mcv_buckets / non_mcv_buckets;
-    }
-  else if (hist_size >= 10)
+  /* Blend the bucket-match fraction with the heuristic. The histogram is trusted in proportion to
+   * (a) how many non-MCV buckets exist, (b) how many of them matched, and (c) how representative
+   * bucket_hi is (avg confidence); when the two estimates disagree, lean further toward the
+   * histogram observation. */
+  double total_non_mcv_sel = pattern_sel;
+
+  if (non_mcv_buckets > 0.0)
     {
       const double matched_buckets_sel = matched_non_mcv_buckets / non_mcv_buckets;
-      const double w = static_cast<double> (hist_size) / 100.0;
-      total_non_mcv_sel = matched_buckets_sel * w + pattern_sel * (1.0 - w);
-    }
-  else
-    {
-      total_non_mcv_sel = pattern_sel;
+
+      /* (a) trust the histogram more as the non-MCV bucket count grows (baseline 64). */
+      const double bucket_count_weight = non_mcv_buckets / (non_mcv_buckets + 64.0);
+
+      /* (b) a single matched bucket is weak evidence; meaningful around 4..8 matches. */
+      const double matched_support_weight = matched_non_mcv_buckets / (matched_non_mcv_buckets + 4.0);
+
+      /* (c) trust bucket_hi less when buckets hold many distinct values. */
+      const double avg_ndv_confidence = ndv_confidence_sum / non_mcv_buckets;
+
+      double hist_weight = bucket_count_weight * matched_support_weight * avg_ndv_confidence;
+      if (hist_weight > 1.0)
+	{
+	  hist_weight = 1.0;
+	}
+      else if (hist_weight < 0.0)
+	{
+	  hist_weight = 0.0;
+	}
+
+      /* when histogram evidence and the heuristic disagree, bias further toward the histogram. */
+      const double eps = 1e-12;
+      const double a = std::max (matched_buckets_sel, eps);
+      const double b = std::max (pattern_sel, eps);
+      const double ratio = std::max (a, b) / std::min (a, b);
+      const double disagreement_boost = (ratio - 1.0) / ratio;
+
+      double boosted_weight = hist_weight + (1.0 - hist_weight) * disagreement_boost;
+      if (boosted_weight > 1.0)
+	{
+	  boosted_weight = 1.0;
+	}
+
+      total_non_mcv_sel = matched_buckets_sel * boosted_weight + pattern_sel * (1.0 - boosted_weight);
     }
 
   /* don't believe extremely small or large estimates for the histogram part. */

--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -41,6 +41,10 @@
 #include "object_accessor.h"
 #include "authenticate.h"
 #include "query_planner.h"
+#include <cmath>
+#include <unordered_map>
+#include <unordered_set>
+
 
 static bool histogram_extract_key (const DB_VALUE *db_val, hist::histogram_key &key);
 
@@ -640,6 +644,11 @@ string_pos (const unsigned char *s, std::size_t len, std::size_t max_len = 16)
 static double
 string_domain_frac_lt (const std::string &lo, const std::string &hi, const std::string &v)
 {
+  if (v <= lo)
+    {
+      return 0.0;
+    }
+
   if (hi <= v)
     {
       return 1.0;
@@ -658,11 +667,22 @@ string_domain_frac_lt (const std::string &lo, const std::string &hi, const std::
 
   if (den <= 0.0)
     {
-      /* phi == plo: two bucket boundaries map to the same position. clamp01 is applied conservatively */
-      return clamp01 ((pv - plo));
+      return clamp01 (pv - plo);
     }
 
-  double t = (pv - plo) / den;
+  double t = clamp01 ((pv - plo) / den);
+
+  if (t > 0.0 && t < 1.0)
+    {
+      t = std::sqrt (t);
+    }
+
+  constexpr double min_interior = 0.01;
+  if (t > 0.0 && t < min_interior)
+    {
+      t = min_interior;
+    }
+
   return clamp01 (t);
 }
 
@@ -818,6 +838,36 @@ histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *s
     {
       *selectivity = 1.0 / total_rows;	/* avoid a zero-cardinality estimate */
     }
+
+  *success = true;
+  return;
+}
+
+void
+histogram_get_default_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success)
+{
+  assert (selectivity != NULL);
+
+  if (rhs_db_value == NULL)
+    {
+      *success = false;
+      return;
+    }
+
+  hist::HistogramReader histogram_reader;
+  if (!histogram_init_reader_from_lhs (lhs, histogram_reader))
+    {
+      *success = false;
+      return;
+    }
+
+  if (histogram_reader.total_rows () <= 0.0)
+    {
+      *success = false;
+      return;
+    }
+
+  *selectivity = 1.0 / (static_cast<double> (histogram_reader.bucket_count ()) * 64.0);
   *success = true;
   return;
 }
@@ -1614,4 +1664,778 @@ dump_histogram (MOP classop, const char *attr_name, DB_TYPE attr_type, bool deta
   db_value_clear (&null_frequency_value);
 
   return NO_ERROR;
+}
+
+/*
+ * Helper: derive histogram key kind from a PT_NODE column.
+ * This is used for eq-join when both lhs and rhs are columns.
+ */
+static bool
+histogram_extract_key_kind_from_node (PT_NODE *node, hist::histogram_key_kind &kind)
+{
+  if (node == NULL)
+    {
+      return false;
+    }
+
+  DB_TYPE type = pt_type_enum_to_db (node->type_enum);
+
+  switch (type)
+    {
+    case DB_TYPE_INTEGER:
+    case DB_TYPE_SHORT:
+    case DB_TYPE_BIGINT:
+      kind = hist::histogram_key_kind::i64;
+      return true;
+
+    case DB_TYPE_FLOAT:
+    case DB_TYPE_DOUBLE:
+    case DB_TYPE_NUMERIC:
+      kind = hist::histogram_key_kind::dbl;
+      return true;
+
+    case DB_TYPE_BIT:
+    case DB_TYPE_VARBIT:
+    case DB_TYPE_CHAR:
+    case DB_TYPE_STRING:
+      kind = hist::histogram_key_kind::str;
+      return true;
+
+    case DB_TYPE_TIME:
+    case DB_TYPE_TIMESTAMP:
+    case DB_TYPE_TIMESTAMPLTZ:
+    case DB_TYPE_DATE:
+    case DB_TYPE_TIMESTAMPTZ:
+    case DB_TYPE_DATETIME:
+    case DB_TYPE_DATETIMETZ:
+    case DB_TYPE_DATETIMELTZ:
+      kind = hist::histogram_key_kind::u64;
+      return true;
+
+    default:
+      return false;
+    }
+}
+
+/*
+ * Helper: sum approximate NDV of all non-MCV buckets.
+ * In this file, approx_ndv == 1 means an exact value bucket (MCV-like).
+ */
+static double
+histogram_sum_non_mcv_ndv (const hist::HistogramReader &reader)
+{
+  double ndv_sum = 0.0;
+
+  for (std::size_t i = 0; i < reader.bucket_count (); ++i)
+    {
+      const int approx_ndv = reader.bucket_approx_ndv (i);
+      if (approx_ndv > 1)
+	{
+	  ndv_sum += static_cast<double> (approx_ndv);
+	}
+    }
+
+  return ndv_sum;
+}
+
+/*
+ * Helper: overlap fraction for numeric ordered domains.
+ * frac1 is the overlap width divided by width(bucket1),
+ * frac2 is the overlap width divided by width(bucket2).
+ */
+static bool
+histogram_bucket_overlap_fraction_i64 (std::int64_t lo1, std::int64_t hi1,
+				       std::int64_t lo2, std::int64_t hi2,
+				       double &frac1, double &frac2)
+{
+  frac1 = 0.0;
+  frac2 = 0.0;
+
+  if (hi1 <= lo1 || hi2 <= lo2)
+    {
+      return false;
+    }
+
+  const std::int64_t overlap_lo = (lo1 < lo2) ? lo2 : lo1;
+  const std::int64_t overlap_hi = (hi1 < hi2) ? hi1 : hi2;
+
+  if (overlap_hi <= overlap_lo)
+    {
+      return false;
+    }
+
+  const long double width1 = static_cast<long double> (hi1) - static_cast<long double> (lo1);
+  const long double width2 = static_cast<long double> (hi2) - static_cast<long double> (lo2);
+  const long double overlap_width = static_cast<long double> (overlap_hi) - static_cast<long double> (overlap_lo);
+
+  if (width1 <= 0.0L || width2 <= 0.0L)
+    {
+      return false;
+    }
+
+  frac1 = clamp01 (static_cast<double> (overlap_width / width1));
+  frac2 = clamp01 (static_cast<double> (overlap_width / width2));
+  return true;
+}
+
+static bool
+histogram_bucket_overlap_fraction_u64 (std::uint64_t lo1, std::uint64_t hi1,
+				       std::uint64_t lo2, std::uint64_t hi2,
+				       double &frac1, double &frac2)
+{
+  frac1 = 0.0;
+  frac2 = 0.0;
+
+  if (hi1 <= lo1 || hi2 <= lo2)
+    {
+      return false;
+    }
+
+  const std::uint64_t overlap_lo = (lo1 < lo2) ? lo2 : lo1;
+  const std::uint64_t overlap_hi = (hi1 < hi2) ? hi1 : hi2;
+
+  if (overlap_hi <= overlap_lo)
+    {
+      return false;
+    }
+
+  const long double width1 = static_cast<long double> (hi1) - static_cast<long double> (lo1);
+  const long double width2 = static_cast<long double> (hi2) - static_cast<long double> (lo2);
+  const long double overlap_width = static_cast<long double> (overlap_hi) - static_cast<long double> (overlap_lo);
+
+  if (width1 <= 0.0L || width2 <= 0.0L)
+    {
+      return false;
+    }
+
+  frac1 = clamp01 (static_cast<double> (overlap_width / width1));
+  frac2 = clamp01 (static_cast<double> (overlap_width / width2));
+  return true;
+}
+
+static bool
+histogram_bucket_overlap_fraction_dbl (double lo1, double hi1,
+				       double lo2, double hi2,
+				       double &frac1, double &frac2)
+{
+  frac1 = 0.0;
+  frac2 = 0.0;
+
+  if (hi1 <= lo1 || hi2 <= lo2)
+    {
+      return false;
+    }
+
+  const double overlap_lo = (lo1 < lo2) ? lo2 : lo1;
+  const double overlap_hi = (hi1 < hi2) ? hi1 : hi2;
+
+  if (overlap_hi <= overlap_lo)
+    {
+      return false;
+    }
+
+  const long double width1 = static_cast<long double> (hi1) - static_cast<long double> (lo1);
+  const long double width2 = static_cast<long double> (hi2) - static_cast<long double> (lo2);
+  const long double overlap_width = static_cast<long double> (overlap_hi) - static_cast<long double> (overlap_lo);
+
+  if (width1 <= 0.0L || width2 <= 0.0L)
+    {
+      return false;
+    }
+
+  frac1 = clamp01 (static_cast<double> (overlap_width / width1));
+  frac2 = clamp01 (static_cast<double> (overlap_width / width2));
+  return true;
+}
+
+/*
+ * String overlap fraction uses the existing string_domain_frac_lt() mapping.
+ * This is only a heuristic, but it is still useful as weak overlap evidence.
+ */
+static bool
+histogram_bucket_overlap_fraction_str (const std::string &lo1, const std::string &hi1,
+				       const std::string &lo2, const std::string &hi2,
+				       double &frac1, double &frac2)
+{
+  frac1 = 0.0;
+  frac2 = 0.0;
+
+  if (hi1 <= lo1 || hi2 <= lo2)
+    {
+      return false;
+    }
+
+  const std::string overlap_lo = (lo1 < lo2) ? lo2 : lo1;
+  const std::string overlap_hi = (hi1 < hi2) ? hi1 : hi2;
+
+  if (overlap_hi <= overlap_lo)
+    {
+      return false;
+    }
+
+  frac1 = clamp01 (string_domain_frac_lt (lo1, hi1, overlap_hi)
+		   - string_domain_frac_lt (lo1, hi1, overlap_lo));
+  frac2 = clamp01 (string_domain_frac_lt (lo2, hi2, overlap_hi)
+		   - string_domain_frac_lt (lo2, hi2, overlap_lo));
+
+  return (frac1 > 0.0 || frac2 > 0.0);
+}
+/*
+ * Stage 2:
+ * Match exact-value buckets (approx_ndv == 1) across lhs and rhs.
+ *
+ * This is the highest-confidence component of eq-join estimation.  Keep
+ * matched and unmatched MCV frequencies separately so the caller can account
+ * for the remaining population in the same spirit as PostgreSQL's
+ * eqjoinsel_inner().
+ *
+ * Implementation note:
+ * Use a hash table for rhs exact buckets to avoid O(lhs_bucket_count * rhs_bucket_count)
+ * pair comparison. This also makes repeated join selectivity estimation less expensive.
+ */
+template <typename T>
+static double
+histogram_eqjoin_exact_mcv_mass_t (const hist::HistogramReader &lhs_reader,
+				   const hist::HistogramReader &rhs_reader,
+				   double lhs_total_rows, double rhs_total_rows,
+				   double &lhs_mcv_rows, double &rhs_mcv_rows,
+				   double &lhs_matched_mcv_frac, double &rhs_matched_mcv_frac,
+				   double &lhs_unmatched_mcv_frac, double &rhs_unmatched_mcv_frac,
+				   int &matched_mcv_count, int &lhs_mcv_count, int &rhs_mcv_count)
+{
+  lhs_mcv_rows = 0.0;
+  rhs_mcv_rows = 0.0;
+  lhs_matched_mcv_frac = 0.0;
+  rhs_matched_mcv_frac = 0.0;
+  lhs_unmatched_mcv_frac = 0.0;
+  rhs_unmatched_mcv_frac = 0.0;
+  matched_mcv_count = 0;
+  lhs_mcv_count = 0;
+  rhs_mcv_count = 0;
+
+  if (lhs_total_rows <= 0.0 || rhs_total_rows <= 0.0)
+    {
+      return 0.0;
+    }
+
+  std::unordered_map<T, double> rhs_prob_by_value;
+  std::unordered_set<T> matched_rhs_values;
+
+  for (std::size_t j = 0; j < rhs_reader.bucket_count (); ++j)
+    {
+      if (rhs_reader.bucket_approx_ndv (j) != 1)
+	{
+	  continue;
+	}
+
+      const double rhs_rows = static_cast<double> (rhs_reader.bucket_rows (j));
+      if (rhs_rows <= 0.0)
+	{
+	  continue;
+	}
+
+      rhs_mcv_rows += rhs_rows;
+      rhs_mcv_count++;
+
+      const T &rhs_val = rhs_reader.bucket_hi<T> (j);
+      rhs_prob_by_value[rhs_val] += rhs_rows / rhs_total_rows;
+    }
+
+  double exact_mass = 0.0;
+
+  for (std::size_t i = 0; i < lhs_reader.bucket_count (); ++i)
+    {
+      if (lhs_reader.bucket_approx_ndv (i) != 1)
+	{
+	  continue;
+	}
+
+      const double lhs_rows = static_cast<double> (lhs_reader.bucket_rows (i));
+      if (lhs_rows <= 0.0)
+	{
+	  continue;
+	}
+
+      lhs_mcv_rows += lhs_rows;
+      lhs_mcv_count++;
+
+      const T &lhs_val = lhs_reader.bucket_hi<T> (i);
+      typename std::unordered_map<T, double>::const_iterator it = rhs_prob_by_value.find (lhs_val);
+      if (it != rhs_prob_by_value.end ())
+	{
+	  const double lhs_prob = lhs_rows / lhs_total_rows;
+	  exact_mass += lhs_prob * it->second;
+	  lhs_matched_mcv_frac += lhs_prob;
+	  matched_rhs_values.insert (lhs_val);
+	  matched_mcv_count++;
+	}
+    }
+
+  for (typename std::unordered_set<T>::const_iterator it = matched_rhs_values.begin ();
+       it != matched_rhs_values.end (); ++it)
+    {
+      typename std::unordered_map<T, double>::const_iterator rhs_it = rhs_prob_by_value.find (*it);
+      if (rhs_it != rhs_prob_by_value.end ())
+	{
+	  rhs_matched_mcv_frac += rhs_it->second;
+	}
+    }
+
+  lhs_unmatched_mcv_frac = clamp01 ((lhs_mcv_rows / lhs_total_rows) - lhs_matched_mcv_frac);
+  rhs_unmatched_mcv_frac = clamp01 ((rhs_mcv_rows / rhs_total_rows) - rhs_matched_mcv_frac);
+
+  return clamp01 (exact_mass);
+}
+
+/*
+ * Stage 3b:
+ * Refine residual non-MCV overlap by scanning bucket pairs and using bucket
+ * overlap as weak evidence of common value-domain coverage.
+ *
+ * Only non-MCV buckets (approx_ndv > 1) are considered here.
+ * For each overlapping bucket pair:
+ *
+ *   local_mass = lhs_overlap_prob * rhs_overlap_prob / max(lhs_overlap_ndv, rhs_overlap_ndv)
+ *
+ * This keeps the estimate conservative while still letting histograms influence
+ * join cardinality beyond simple NDV fallback.
+ */
+template <typename T, typename OverlapFunc>
+static double
+histogram_eqjoin_residual_overlap_mass_t (const hist::HistogramReader &lhs_reader,
+    const hist::HistogramReader &rhs_reader,
+    double lhs_total_rows, double rhs_total_rows,
+    OverlapFunc overlap_func)
+{
+  double residual_mass = 0.0;
+
+  /*
+   * We require i >= 1 and j >= 1 because a non-MCV bucket needs a lower
+   * boundary from the previous bucket's endpoint.
+   */
+  for (std::size_t i = 1; i < lhs_reader.bucket_count (); ++i)
+    {
+      const int lhs_ndv_i = lhs_reader.bucket_approx_ndv (i);
+      if (lhs_ndv_i <= 1)
+	{
+	  continue;
+	}
+
+      const double lhs_bucket_rows = static_cast<double> (lhs_reader.bucket_rows (i));
+      if (lhs_bucket_rows <= 0.0)
+	{
+	  continue;
+	}
+
+      const T &lhs_lo = lhs_reader.bucket_hi<T> (i - 1);
+      const T &lhs_hi = lhs_reader.bucket_hi<T> (i);
+
+      for (std::size_t j = 1; j < rhs_reader.bucket_count (); ++j)
+	{
+	  const int rhs_ndv_j = rhs_reader.bucket_approx_ndv (j);
+	  if (rhs_ndv_j <= 1)
+	    {
+	      continue;
+	    }
+
+	  const double rhs_bucket_rows = static_cast<double> (rhs_reader.bucket_rows (j));
+	  if (rhs_bucket_rows <= 0.0)
+	    {
+	      continue;
+	    }
+
+	  const T &rhs_lo = rhs_reader.bucket_hi<T> (j - 1);
+	  const T &rhs_hi = rhs_reader.bucket_hi<T> (j);
+
+	  double lhs_overlap_frac = 0.0;
+	  double rhs_overlap_frac = 0.0;
+
+	  if (!overlap_func (lhs_lo, lhs_hi, rhs_lo, rhs_hi, lhs_overlap_frac, rhs_overlap_frac))
+	    {
+	      continue;
+	    }
+
+	  if (lhs_overlap_frac <= 0.0 || rhs_overlap_frac <= 0.0)
+	    {
+	      continue;
+	    }
+
+	  double lhs_overlap_ndv = static_cast<double> (lhs_ndv_i) * lhs_overlap_frac;
+	  double rhs_overlap_ndv = static_cast<double> (rhs_ndv_j) * rhs_overlap_frac;
+
+	  if (lhs_overlap_ndv < 1.0)
+	    {
+	      lhs_overlap_ndv = 1.0;
+	    }
+	  if (rhs_overlap_ndv < 1.0)
+	    {
+	      rhs_overlap_ndv = 1.0;
+	    }
+
+	  const double lhs_overlap_prob = (lhs_bucket_rows / lhs_total_rows) * lhs_overlap_frac;
+	  const double rhs_overlap_prob = (rhs_bucket_rows / rhs_total_rows) * rhs_overlap_frac;
+
+	  const double local_join_sel = 1.0 / ((lhs_overlap_ndv > rhs_overlap_ndv) ? lhs_overlap_ndv : rhs_overlap_ndv);
+
+	  residual_mass += lhs_overlap_prob * rhs_overlap_prob * local_join_sel;
+	}
+    }
+
+  return clamp01 (residual_mass);
+}
+
+/*
+ * Stage 3a:
+ * Conservative residual fallback using non-MCV NDV only.
+ */
+static double
+histogram_eqjoin_residual_fallback_mass (const hist::HistogramReader &lhs_reader,
+    const hist::HistogramReader &rhs_reader,
+    double lhs_non_mcv_frac, double rhs_non_mcv_frac)
+{
+  const double lhs_residual_ndv = histogram_sum_non_mcv_ndv (lhs_reader);
+  const double rhs_residual_ndv = histogram_sum_non_mcv_ndv (rhs_reader);
+
+  if (lhs_residual_ndv <= 0.0 || rhs_residual_ndv <= 0.0)
+    {
+      return 0.0;
+    }
+
+  const double residual_sel = 1.0 / ((lhs_residual_ndv > rhs_residual_ndv)
+				     ? lhs_residual_ndv : rhs_residual_ndv);
+
+  return clamp01 (lhs_non_mcv_frac * rhs_non_mcv_frac * residual_sel);
+}
+
+/*
+ * PostgreSQL-style residual estimate for the part not covered by exact MCV
+ * matches.  This accounts for unmatched MCVs against the opposite non-MCV
+ * population, plus non-MCV values against unmatched MCVs/non-MCV values.
+ */
+static double
+histogram_eqjoin_pg_mcv_residual_mass (double exact_mcv_mass,
+				       double lhs_unmatched_mcv_frac, double rhs_unmatched_mcv_frac,
+				       double lhs_other_frac, double rhs_other_frac,
+				       double lhs_total_ndv, double rhs_total_ndv,
+				       int lhs_mcv_count, int rhs_mcv_count, int matched_mcv_count)
+{
+  double lhs_view = exact_mcv_mass;
+  double rhs_view = exact_mcv_mass;
+  double rhs_unmatched_denom;
+  double lhs_unmatched_denom;
+  double rhs_remaining_denom;
+  double lhs_remaining_denom;
+
+  lhs_other_frac = clamp01 (lhs_other_frac);
+  rhs_other_frac = clamp01 (rhs_other_frac);
+  lhs_unmatched_mcv_frac = clamp01 (lhs_unmatched_mcv_frac);
+  rhs_unmatched_mcv_frac = clamp01 (rhs_unmatched_mcv_frac);
+
+  rhs_unmatched_denom = rhs_total_ndv - (double) rhs_mcv_count;
+  if (rhs_unmatched_denom > 0.0)
+    {
+      lhs_view += lhs_unmatched_mcv_frac * rhs_other_frac / rhs_unmatched_denom;
+    }
+
+  rhs_remaining_denom = rhs_total_ndv - (double) matched_mcv_count;
+  if (rhs_remaining_denom > 0.0)
+    {
+      lhs_view += lhs_other_frac * (rhs_other_frac + rhs_unmatched_mcv_frac) / rhs_remaining_denom;
+    }
+
+  lhs_unmatched_denom = lhs_total_ndv - (double) lhs_mcv_count;
+  if (lhs_unmatched_denom > 0.0)
+    {
+      rhs_view += rhs_unmatched_mcv_frac * lhs_other_frac / lhs_unmatched_denom;
+    }
+
+  lhs_remaining_denom = lhs_total_ndv - (double) matched_mcv_count;
+  if (lhs_remaining_denom > 0.0)
+    {
+      rhs_view += rhs_other_frac * (lhs_other_frac + lhs_unmatched_mcv_frac) / lhs_remaining_denom;
+    }
+
+  return clamp01 ((lhs_view < rhs_view) ? lhs_view : rhs_view);
+}
+
+/*
+ * histogram_get_eqjoin_selectivity () - Estimate equality join selectivity
+ *                                       when both lhs and rhs are columns.
+ *
+ * This function implements the 3-stage design:
+ *
+ *   Stage 1. Establish a safe baseline using residual NDV logic.
+ *   Stage 2. Add exact mass from exact-value buckets (MCV buckets).
+ *   Stage 3. Estimate the remaining non-MCV overlap, preferably with
+ *            bucket overlap refinement, and fall back to residual NDV
+ *            when no overlap signal is available.
+ */
+void
+histogram_get_eqjoin_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity, bool *success)
+{
+  assert (selectivity != NULL);
+  assert (success != NULL);
+
+  *selectivity = 0.0;
+  *success = false;
+
+  if (lhs == NULL || rhs == NULL)
+    {
+      return;
+    }
+
+  hist::HistogramReader lhs_reader;
+  hist::HistogramReader rhs_reader;
+
+  if (!histogram_init_reader_from_lhs (lhs, lhs_reader)
+      || !histogram_init_reader_from_lhs (rhs, rhs_reader))
+    {
+      return;
+    }
+
+  hist::histogram_key_kind lhs_kind = hist::histogram_key_kind::invalid;
+  hist::histogram_key_kind rhs_kind = hist::histogram_key_kind::invalid;
+
+  if (!histogram_extract_key_kind_from_node (lhs, lhs_kind)
+      || !histogram_extract_key_kind_from_node (rhs, rhs_kind))
+    {
+      return;
+    }
+
+  /*
+   * For now, require both sides to share the same histogram domain kind.
+   * Mixed numeric kinds (e.g. i64 vs dbl) can be added later if needed.
+   */
+  if (lhs_kind != rhs_kind)
+    {
+      return;
+    }
+
+  const double lhs_total_rows = static_cast<double> (lhs_reader.total_rows ());
+  const double rhs_total_rows = static_cast<double> (rhs_reader.total_rows ());
+
+  if (lhs_total_rows <= 0.0 || rhs_total_rows <= 0.0)
+    {
+      *selectivity = 0.0;
+      *success = true;
+      return;
+    }
+
+  double lhs_mcv_rows = 0.0;
+  double rhs_mcv_rows = 0.0;
+  double exact_mcv_mass = 0.0;
+  double overlap_residual_mass = 0.0;
+  double lhs_matched_mcv_frac = 0.0;
+  double rhs_matched_mcv_frac = 0.0;
+  double lhs_unmatched_mcv_frac = 0.0;
+  double rhs_unmatched_mcv_frac = 0.0;
+  int matched_mcv_count = 0;
+  int lhs_mcv_count = 0;
+  int rhs_mcv_count = 0;
+
+  switch (lhs_kind)
+    {
+    case hist::histogram_key_kind::i64:
+      exact_mcv_mass =
+	      histogram_eqjoin_exact_mcv_mass_t<std::int64_t> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  lhs_mcv_rows, rhs_mcv_rows,
+		  lhs_matched_mcv_frac, rhs_matched_mcv_frac,
+		  lhs_unmatched_mcv_frac, rhs_unmatched_mcv_frac,
+		  matched_mcv_count, lhs_mcv_count, rhs_mcv_count);
+
+      overlap_residual_mass =
+	      histogram_eqjoin_residual_overlap_mass_t<std::int64_t> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  histogram_bucket_overlap_fraction_i64);
+      break;
+
+    case hist::histogram_key_kind::dbl:
+      exact_mcv_mass =
+	      histogram_eqjoin_exact_mcv_mass_t<double> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  lhs_mcv_rows, rhs_mcv_rows,
+		  lhs_matched_mcv_frac, rhs_matched_mcv_frac,
+		  lhs_unmatched_mcv_frac, rhs_unmatched_mcv_frac,
+		  matched_mcv_count, lhs_mcv_count, rhs_mcv_count);
+
+      overlap_residual_mass =
+	      histogram_eqjoin_residual_overlap_mass_t<double> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  histogram_bucket_overlap_fraction_dbl);
+      break;
+
+    case hist::histogram_key_kind::str:
+      exact_mcv_mass =
+	      histogram_eqjoin_exact_mcv_mass_t<std::string> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  lhs_mcv_rows, rhs_mcv_rows,
+		  lhs_matched_mcv_frac, rhs_matched_mcv_frac,
+		  lhs_unmatched_mcv_frac, rhs_unmatched_mcv_frac,
+		  matched_mcv_count, lhs_mcv_count, rhs_mcv_count);
+
+      overlap_residual_mass =
+	      histogram_eqjoin_residual_overlap_mass_t<std::string> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  histogram_bucket_overlap_fraction_str);
+      break;
+
+    case hist::histogram_key_kind::u64:
+      exact_mcv_mass =
+	      histogram_eqjoin_exact_mcv_mass_t<std::uint64_t> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  lhs_mcv_rows, rhs_mcv_rows,
+		  lhs_matched_mcv_frac, rhs_matched_mcv_frac,
+		  lhs_unmatched_mcv_frac, rhs_unmatched_mcv_frac,
+		  matched_mcv_count, lhs_mcv_count, rhs_mcv_count);
+
+      overlap_residual_mass =
+	      histogram_eqjoin_residual_overlap_mass_t<std::uint64_t> (lhs_reader, rhs_reader,
+		  lhs_total_rows, rhs_total_rows,
+		  histogram_bucket_overlap_fraction_u64);
+      break;
+
+    case hist::histogram_key_kind::invalid:
+    default:
+      return;
+    }
+
+  /*
+   * Stage 1 baseline:
+   * Derive the residual non-MCV mass cap from remaining row fractions,
+   * then compute the NDV-based fallback for that region.
+   */
+  double lhs_non_mcv_frac = (lhs_total_rows - lhs_mcv_rows) / lhs_total_rows;
+  double rhs_non_mcv_frac = (rhs_total_rows - rhs_mcv_rows) / rhs_total_rows;
+
+  lhs_non_mcv_frac = clamp01 (lhs_non_mcv_frac);
+  rhs_non_mcv_frac = clamp01 (rhs_non_mcv_frac);
+
+  const double lhs_total_ndv = histogram_sum_non_mcv_ndv (lhs_reader) + (double) lhs_mcv_count;
+  const double rhs_total_ndv = histogram_sum_non_mcv_ndv (rhs_reader) + (double) rhs_mcv_count;
+  const double fallback_residual_mass =
+	  histogram_eqjoin_residual_fallback_mass (lhs_reader, rhs_reader,
+	      lhs_non_mcv_frac, rhs_non_mcv_frac);
+  const double pg_mcv_mass =
+	  histogram_eqjoin_pg_mcv_residual_mass (exact_mcv_mass,
+	      lhs_unmatched_mcv_frac, rhs_unmatched_mcv_frac,
+	      lhs_non_mcv_frac, rhs_non_mcv_frac,
+	      lhs_total_ndv, rhs_total_ndv,
+	      lhs_mcv_count, rhs_mcv_count, matched_mcv_count);
+
+  /*
+   * Stage 3 final residual choice:
+   *
+   * Start from the PG-style MCV/non-MCV decomposition when MCVs are available.
+   * If MCV decomposition is unavailable, use the global non-MCV NDV fallback.
+   * Bucket overlap is only a reducing signal. It must not increase residual
+   * equality join selectivity above the chosen statistical baseline.
+   *
+   * This is important for join ordering because range overlap between histogram
+   * buckets is weak evidence. If we let overlap_residual_mass replace the
+   * fallback whenever it is positive, common id-like domains can make joins look
+   * much less selective than they should be.
+   */
+  const bool has_both_mcv_lists = (lhs_mcv_count > 0 && rhs_mcv_count > 0);
+  double selectivity_mass = has_both_mcv_lists ? pg_mcv_mass : exact_mcv_mass + fallback_residual_mass;
+
+  if (!has_both_mcv_lists && overlap_residual_mass > 0.0)
+    {
+      double overlap_mass = exact_mcv_mass + overlap_residual_mass;
+
+      if (overlap_mass < selectivity_mass)
+	{
+	  selectivity_mass = overlap_mass;
+	}
+    }
+
+  /*
+   * Final join selectivity:
+   *
+   *   exact MCV contribution
+   * + matched/unmatched MCV and non-MCV contribution
+   */
+  *selectivity = clamp01 (selectivity_mass);
+
+  const double lhs_non_null_frac = clamp01 (1.0 - lhs->info.name.null_frequency);
+  const double rhs_non_null_frac = clamp01 (1.0 - rhs->info.name.null_frequency);
+
+  *selectivity = clamp01 (*selectivity * lhs_non_null_frac * rhs_non_null_frac);
+
+  *success = true;
+}
+
+/*
+ * histogram_get_max_mcv_frequency () - get the largest single MCV frequency
+ *
+ * max_mcv_frequency = max(rows of one bucket whose approx_ndv == 1) / total histogram rows
+ *
+ * In this histogram format, approx_ndv == 1 means exact-value bucket,
+ * which is treated as an MCV bucket.
+ */
+void
+histogram_get_max_mcv_frequency (PT_NODE *pt_col, double *out_max_mcv_frequency, bool *out_success)
+{
+  hist::HistogramReader reader;
+  double total_rows = 0.0;
+  double max_mcv_rows = 0.0;
+
+  if (out_max_mcv_frequency != NULL)
+    {
+      *out_max_mcv_frequency = 0.0;
+    }
+
+  if (out_success != NULL)
+    {
+      *out_success = false;
+    }
+
+  if (pt_col == NULL || out_max_mcv_frequency == NULL || out_success == NULL)
+    {
+      return;
+    }
+
+  if (!histogram_init_reader_from_lhs (pt_col, reader))
+    {
+      return;
+    }
+
+  total_rows = static_cast<double> (reader.total_rows ());
+  if (total_rows <= 0.0)
+    {
+      return;
+    }
+
+  for (std::size_t i = 0; i < reader.bucket_count (); i++)
+    {
+      const int approx_ndv = reader.bucket_approx_ndv (i);
+
+      if (approx_ndv != 1)
+	{
+	  continue;
+	}
+
+      const double bucket_rows = static_cast<double> (reader.bucket_rows (i));
+      if (bucket_rows <= 0.0)
+	{
+	  continue;
+	}
+
+      if (bucket_rows > max_mcv_rows)
+	{
+	  max_mcv_rows = bucket_rows;
+	}
+    }
+
+  if (max_mcv_rows < 0.0)
+    {
+      max_mcv_rows = 0.0;
+    }
+  else if (max_mcv_rows > total_rows)
+    {
+      max_mcv_rows = total_rows;
+    }
+
+  *out_max_mcv_frequency = clamp01 (max_mcv_rows / total_rows);
+  *out_success = true;
 }

--- a/src/optimizer/histogram/histogram_cl.cpp
+++ b/src/optimizer/histogram/histogram_cl.cpp
@@ -1951,49 +1951,43 @@ histogram_eqjoin_exact_mcv_mass_t (const hist::HistogramReader &lhs_reader,
   std::unordered_map<T, double> rhs_prob_by_value;
   std::unordered_set<T> matched_rhs_values;
 
-  for (std::size_t j = 0; j < rhs_reader.bucket_count (); ++j)
+  /* Iterate the histogram's MCV list, NOT the buckets. In the reservoir v2 blob the MCVs are stored
+   * in a separate list (mcv_count/mcv_hi/mcv_freq) and bucket_* holds only the non-MCV residual, so
+   * reading MCVs from buckets misses them entirely (e.g. role_type.id has 12 MCVs / 0 buckets ->
+   * the old bucket loop saw 0 MCVs and returned mass 0). mcv_freq() is already a row fraction. */
+  for (std::uint32_t j = 0; j < static_cast<std::uint32_t> (rhs_reader.mcv_count ()); ++j)
     {
-      if (rhs_reader.bucket_approx_ndv (j) != 1)
+      const double rhs_freq = rhs_reader.mcv_freq (j);
+      if (rhs_freq <= 0.0)
 	{
 	  continue;
 	}
 
-      const double rhs_rows = static_cast<double> (rhs_reader.bucket_rows (j));
-      if (rhs_rows <= 0.0)
-	{
-	  continue;
-	}
-
-      rhs_mcv_rows += rhs_rows;
+      rhs_mcv_rows += rhs_freq * rhs_total_rows;
       rhs_mcv_count++;
 
-      const T &rhs_val = rhs_reader.bucket_hi<T> (j);
-      rhs_prob_by_value[rhs_val] += rhs_rows / rhs_total_rows;
+      const T rhs_val = rhs_reader.mcv_hi<T> (j);
+      rhs_prob_by_value[rhs_val] += rhs_freq;
     }
 
   double exact_mass = 0.0;
 
-  for (std::size_t i = 0; i < lhs_reader.bucket_count (); ++i)
+  for (std::uint32_t i = 0; i < static_cast<std::uint32_t> (lhs_reader.mcv_count ()); ++i)
     {
-      if (lhs_reader.bucket_approx_ndv (i) != 1)
+      const double lhs_freq = lhs_reader.mcv_freq (i);
+      if (lhs_freq <= 0.0)
 	{
 	  continue;
 	}
 
-      const double lhs_rows = static_cast<double> (lhs_reader.bucket_rows (i));
-      if (lhs_rows <= 0.0)
-	{
-	  continue;
-	}
-
-      lhs_mcv_rows += lhs_rows;
+      lhs_mcv_rows += lhs_freq * lhs_total_rows;
       lhs_mcv_count++;
 
-      const T &lhs_val = lhs_reader.bucket_hi<T> (i);
+      const T lhs_val = lhs_reader.mcv_hi<T> (i);
       typename std::unordered_map<T, double>::const_iterator it = rhs_prob_by_value.find (lhs_val);
       if (it != rhs_prob_by_value.end ())
 	{
-	  const double lhs_prob = lhs_rows / lhs_total_rows;
+	  const double lhs_prob = lhs_freq;
 	  exact_mass += lhs_prob * it->second;
 	  lhs_matched_mcv_frac += lhs_prob;
 	  matched_rhs_values.insert (lhs_val);
@@ -2391,6 +2385,26 @@ histogram_get_eqjoin_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivit
   const double rhs_non_null_frac = clamp01 (1.0 - rhs->info.name.null_frequency);
 
   *selectivity = clamp01 (*selectivity * lhs_non_null_frac * rhs_non_null_frac);
+
+  /* Floor at 1/max(NDV): an equi-join over distinct keys cannot be more selective than matching one
+   * value on the larger side. This catches degenerate distributions the MCV/residual decomposition
+   * misses, e.g. one side all non-MCV (info_type.id: 113 buckets, 0 MCVs) joining a side whose MCVs
+   * cover ~all rows (movie_info.info_type_id) -> residual mass collapses to 0. NOTE: relies on the
+   * MCV-list-based NDV being correct (lhs/rhs_total_ndv = non-MCV bucket NDV + mcv_count); with the
+   * old bucket-read NDV this floored to absurd values (e.g. 1/2 = 0.5). */
+  {
+    const double max_ndv = (lhs_total_ndv > rhs_total_ndv) ? lhs_total_ndv : rhs_total_ndv;
+
+    if (max_ndv >= 1.0)
+      {
+	const double sel_floor = 1.0 / max_ndv;
+
+	if (*selectivity < sel_floor)
+	  {
+	    *selectivity = sel_floor;
+	  }
+      }
+  }
 
   *success = true;
 }

--- a/src/optimizer/histogram/histogram_cl.hpp
+++ b/src/optimizer/histogram/histogram_cl.hpp
@@ -81,6 +81,7 @@ void histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, doub
 void histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool is_ge, bool include_equal,
 				     double *selectivity,
 				     bool *success);
+void histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success);
 void histogram_get_default_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success);
 void histogram_get_eqjoin_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity, bool *success);
 void histogram_get_max_mcv_frequency (PT_NODE *pt_col, double *out_max_mcv_frequency, bool *out_success);

--- a/src/optimizer/histogram/histogram_cl.hpp
+++ b/src/optimizer/histogram/histogram_cl.hpp
@@ -81,7 +81,9 @@ void histogram_get_equal_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, doub
 void histogram_get_comp_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, bool is_ge, bool include_equal,
 				     double *selectivity,
 				     bool *success);
-void histogram_get_like_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success);
+void histogram_get_default_selectivity (PT_NODE *lhs, DB_VALUE *rhs_db_value, double *selectivity, bool *success);
+void histogram_get_eqjoin_selectivity (PT_NODE *lhs, PT_NODE *rhs, double *selectivity, bool *success);
+void histogram_get_max_mcv_frequency (PT_NODE *pt_col, double *out_max_mcv_frequency, bool *out_success);
 /* histogram utility functions */
 int db_get_histogram (MOP classop, const char *attr_name, DB_OBJECT **histogram_obj);
 bool is_histogrammable_type (DB_TYPE type);

--- a/src/optimizer/plan_generation.c
+++ b/src/optimizer/plan_generation.c
@@ -38,6 +38,7 @@
 #include "xasl.h"
 #include "xasl_generation.h"
 #include "xasl_predicate.hpp"
+#include <cmath>
 
 typedef int (*ELIGIBILITY_FN) (QO_TERM *);
 
@@ -1409,6 +1410,44 @@ is_always_true (QO_TERM * term)
   return true;
 }
 
+static double
+qo_pred_rank_weight (int rank)
+{
+  switch (rank)
+    {
+    case 0:
+    case 1:
+      return 1.0;
+
+    case 2:
+      return 1.5;
+
+    case 3:
+      return 8.0;
+
+    default:
+      return 12.0;
+    }
+}
+
+static double
+qo_pred_eval_score (double sel, int rank)
+{
+  double weight;
+
+  if (sel <= 0.0)
+    {
+      sel = 1e-12;
+    }
+  else if (sel > 1.0)
+    {
+      sel = 1.0;
+    }
+
+  weight = qo_pred_rank_weight (rank);
+  return -std::log (sel) / weight;
+}
+
 /*
  * make_pred_from_bitset () -
  *   return: PT_NODE *
@@ -1437,6 +1476,8 @@ make_pred_from_bitset (QO_ENV * env, BITSET * predset, ELIGIBILITY_FN safe)
   pred_list = NULL;		/* init */
   for (i = bitset_iterate (predset, &bi); i != -1; i = bitset_next_member (&bi))
     {
+      double pointer_score;
+
       term = QO_ENV_TERM (env, i);
 
       /* Don't ever let one of our fabricated terms find its way into the predicate; that will cause serious confusion. */
@@ -1459,21 +1500,37 @@ make_pred_from_bitset (QO_ENV * env, BITSET * predset, ELIGIBILITY_FN safe)
 	  goto exit_on_error;
 	}
 
-      /* set AND predicate evaluation pred_order desc, selectivity asc, rank asc */
+      /* keep original metadata for downstream use/debug */
       pointer->info.pointer.sel = QO_TERM_SELECTIVITY (term);
       pointer->info.pointer.rank = QO_TERM_RANK (term);
       pointer->info.pointer.pred_order = QO_TERM_PRED_ORDER (term);
 
-      /* insert to the AND predicate list by descending order of (selectivity, rank) vector; this order is used at
-       * pt_to_pred_expr_with_arg() */
+      pointer_score = qo_pred_eval_score (pointer->info.pointer.sel, pointer->info.pointer.rank);
+
+      /*
+       * insert to the AND predicate list on:
+       *   1) pred_order desc
+       *   2) effective score desc
+       *   3) selectivity asc
+       *   4) rank asc
+       */
       found = false;		/* init */
       prev = NULL;		/* init */
       for (curr = pred_list; curr; curr = curr->next)
 	{
+	  double curr_score;
+
+	  curr_score = qo_pred_eval_score (curr->info.pointer.sel, curr->info.pointer.rank);
+
 	  cmp = pointer->info.pointer.pred_order - curr->info.pointer.pred_order;
 
 	  if (cmp == 0)
-	    {			/* same selectivity, re-compare rank */
+	    {
+	      cmp = pointer_score - curr_score;
+	    }
+
+	  if (cmp == 0)
+	    {
 	      cmp = curr->info.pointer.sel - pointer->info.pointer.sel;
 	    }
 

--- a/src/optimizer/query_graph.c
+++ b/src/optimizer/query_graph.c
@@ -43,6 +43,7 @@
 #include "optimizer.h"
 #include "query_graph.h"
 #include "query_planner.h"
+#include "histogram_cl.hpp"
 #include "schema_manager.h"
 #include "statistics.h"
 #include "system_parameter.h"
@@ -1766,6 +1767,8 @@ qo_add_term (PT_NODE * conjunct, int term_type, QO_ENV * env)
   QO_TERM_MULTI_COL_SEGS (term) = NULL;	/* init */
   QO_TERM_MULTI_COL_CNT (term) = 0;	/* init */
   QO_TERM_PRED_ORDER (term) = pt_is_expr_node (conjunct) ? conjunct->info.expr.pred_order : 0;
+  QO_TERM_HEAD_MCV_MAX_FREQUENCY (term) = 0.0;
+  QO_TERM_TAIL_MCV_MAX_FREQUENCY (term) = 0.0;
 
   env->nterms++;
 
@@ -2788,6 +2791,35 @@ wrapup:
 
     case PREDICATE_TERM:
       QO_TERM_SELECTIVITY (term) = qo_expr_selectivity (env, pt_expr);
+
+      if (qo_is_equi_join_term (term))
+	{
+	  double lhs_mcv_max_frequency = 0.0;
+	  double rhs_mcv_max_frequency = 0.0;
+	  bool success1 = false;
+	  bool success2 = false;
+	  histogram_get_max_mcv_frequency (pt_expr->info.expr.arg1, &lhs_mcv_max_frequency, &success1);
+	  histogram_get_max_mcv_frequency (pt_expr->info.expr.arg2, &rhs_mcv_max_frequency, &success2);
+	  if (success1 || success2)
+	    {
+	      if (head_node != NULL && BITSET_MEMBER (lhs_nodes, QO_NODE_IDX (head_node)))
+		{
+		  QO_TERM_HEAD_MCV_MAX_FREQUENCY (term) = success1 ? lhs_mcv_max_frequency : 0.0;
+		  QO_TERM_TAIL_MCV_MAX_FREQUENCY (term) = success2 ? rhs_mcv_max_frequency : 0.0;
+		}
+	      else
+		{
+		  QO_TERM_HEAD_MCV_MAX_FREQUENCY (term) = success2 ? rhs_mcv_max_frequency : 0.0;
+		  QO_TERM_TAIL_MCV_MAX_FREQUENCY (term) = success1 ? lhs_mcv_max_frequency : 0.0;
+		}
+	    }
+	  else
+	    {
+	      QO_TERM_HEAD_MCV_MAX_FREQUENCY (term) = 0.0;
+	      QO_TERM_TAIL_MCV_MAX_FREQUENCY (term) = 0.0;
+	    }
+	}
+
       break;
 
     default:
@@ -6088,6 +6120,8 @@ qo_exchange (QO_TERM * t0, QO_TERM * t1)
   BITSET_EXCHANGE (t0->nodes, t1->nodes);
   BITSET_EXCHANGE (t0->segments, t1->segments);
   DOUBLE_EXCHANGE (t0->selectivity, t1->selectivity);
+  DOUBLE_EXCHANGE (t0->head_mcv_max_frequency, t1->head_mcv_max_frequency);
+  DOUBLE_EXCHANGE (t0->tail_mcv_max_frequency, t1->tail_mcv_max_frequency);
   INT_EXCHANGE (t0->rank, t1->rank);
   PT_NODE_EXCHANGE (t0->pt_expr, t1->pt_expr);
   INT_EXCHANGE (t0->location, t1->location);
@@ -6109,6 +6143,119 @@ qo_exchange (QO_TERM * t0, QO_TERM * t1)
   /*
    * DON'T exchange the 'idx' values!
    */
+}
+
+static double
+qo_rank_weight (int rank)
+{
+  switch (rank)
+    {
+    case 0:
+    case 1:
+      return 1.0;
+
+    case 2:
+      return 1.5;
+
+    case 3:
+      return 8.0;
+
+    default:
+      return 12.0;
+    }
+}
+
+static double
+qo_term_eval_weight (QO_TERM * term)
+{
+  PT_NODE *expr;
+  PT_NODE *lhs;
+  PT_NODE *rhs;
+
+  if (term == NULL)
+    {
+      return 1.0;
+    }
+
+  expr = QO_TERM_PT_EXPR (term);
+  if (expr == NULL || expr->node_type != PT_EXPR)
+    {
+      return 1.0;
+    }
+
+  lhs = expr->info.expr.arg1;
+  rhs = expr->info.expr.arg2;
+
+  switch (expr->info.expr.op)
+    {
+    case PT_EQ:
+    case PT_NE:
+    case PT_NULLSAFE_EQ:
+      if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	{
+	  return 1.1;
+	}
+      return 1.0;
+
+    case PT_LT:
+    case PT_LE:
+    case PT_GT:
+    case PT_GE:
+    case PT_BETWEEN:
+    case PT_RANGE:
+      if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	{
+	  return 1.25;
+	}
+      return 1.0;
+
+    case PT_LIKE:
+      if (rhs != NULL && rhs->node_type == PT_VALUE)
+	{
+	  const char *pat = db_get_string (&rhs->info.value.db_value);
+	  if (pat != NULL)
+	    {
+	      const char *pct = strchr (pat, '%');
+	      const char *und = strchr (pat, '_');
+
+	      if (pct != NULL && pct[1] == '\0' && und == NULL && pct != pat)
+		{
+		  return 1.25;	/* prefix like 'abc%' */
+		}
+
+	      if (pat[0] == '%' || und != NULL)
+		{
+		  return 2.5;	/* contains/complex pattern */
+		}
+	    }
+	}
+      return 1.5;
+
+    default:
+      return 1.0;
+    }
+}
+
+static double
+qo_term_eval_score (QO_TERM * term)
+{
+  double sel;
+  double weight;
+
+  sel = QO_TERM_SELECTIVITY (term);
+
+  if (sel <= 0.0)
+    {
+      sel = 1e-12;
+    }
+  else if (sel > 1.0)
+    {
+      sel = 1.0;
+    }
+
+  weight = qo_term_eval_weight (term);
+
+  return (1.0 - sel) / weight;
 }
 
 /*
@@ -6169,25 +6316,68 @@ qo_discover_edges (QO_ENV * env)
 	  if (QO_TERM_SELECTIVITY (term1) < QO_TERM_SELECTIVITY (term2))
 	    {
 	      qo_exchange (term1, term2);
+	      term1 = QO_ENV_TERM (env, t1);
 	    }
 	}
     }
-  /* sort sarg-term on pred_order desc, selectivity asc */
+
+  /*
+   * IMPORTANT:
+   * get_rank() is normally called after qo_discover_edges() in qo_optimize_helper().
+   * If we want to use rank here for sarg-term ordering, compute it here explicitly.
+   */
+  for (t1 = i; t1 < env->nterms; t1++)
+    {
+      get_term_rank (env, QO_ENV_TERM (env, t1));
+    }
+
+  /*
+   * sort sarg-term on:
+   *   1) pred_order desc
+   *   2) effective score desc
+   *      effective score = -log(selectivity) / rank_weight
+   *   3) selectivity asc
+   *   4) rank asc
+   */
   for (t1 = i; t1 < env->nterms - 1; t1++)
     {
       term1 = QO_ENV_TERM (env, t1);
+
       for (t2 = t1 + 1; t2 < env->nterms; t2++)
 	{
+	  double score1, score2;
+
 	  term2 = QO_ENV_TERM (env, t2);
 
 	  if (QO_TERM_PRED_ORDER (term1) < QO_TERM_PRED_ORDER (term2))
 	    {
 	      qo_exchange (term1, term2);
+	      term1 = QO_ENV_TERM (env, t1);
 	    }
-	  else if ((QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2))
-		   && (QO_TERM_SELECTIVITY (term1) > QO_TERM_SELECTIVITY (term2)))
+	  else if (QO_TERM_PRED_ORDER (term1) == QO_TERM_PRED_ORDER (term2))
 	    {
-	      qo_exchange (term1, term2);
+	      score1 = qo_term_eval_score (term1);
+	      score2 = qo_term_eval_score (term2);
+
+	      if (score1 < score2)
+		{
+		  qo_exchange (term1, term2);
+		  term1 = QO_ENV_TERM (env, t1);
+		}
+	      else if (fabs (score1 - score2) <= 1e-12)
+		{
+		  if (QO_TERM_SELECTIVITY (term1) > QO_TERM_SELECTIVITY (term2))
+		    {
+		      qo_exchange (term1, term2);
+		      term1 = QO_ENV_TERM (env, t1);
+		    }
+		  else if (QO_TERM_SELECTIVITY (term1) == QO_TERM_SELECTIVITY (term2)
+			   && QO_TERM_RANK (term1) > QO_TERM_RANK (term2))
+		    {
+		      qo_exchange (term1, term2);
+		      term1 = QO_ENV_TERM (env, t1);
+		    }
+		}
 	    }
 	}
     }
@@ -6240,7 +6430,7 @@ qo_discover_edges (QO_ENV * env)
 		{
 		  bitset_union (&direct_nodes, &(QO_TERM_NODES (edge2)));
 		}
-	    }			/* for (j = 0; ...) */
+	    }
 
 	  /* check for direct connected nodes */
 	  for (t = bitset_iterate (&direct_nodes, &iter); t != -1; t = bitset_next_member (&iter))
@@ -6248,7 +6438,7 @@ qo_discover_edges (QO_ENV * env)
 	      node = QO_ENV_NODE (env, t);
 	      if (!QO_NODE_SARGABLE (node))
 		{
-		  break;	/* give up */
+		  break;
 		}
 	    }
 

--- a/src/optimizer/query_graph.h
+++ b/src/optimizer/query_graph.h
@@ -627,6 +627,12 @@ struct qo_term
   double selectivity;
 
   /*
+   * The largest single-MCV frequency for each join side.
+   */
+  double head_mcv_max_frequency;
+  double tail_mcv_max_frequency;
+
+  /*
    * The "flavor" of this term.  This is determined by analysis of the
    * segment or where-clause disjunct that gives rise to the term.
    */
@@ -724,6 +730,8 @@ struct qo_term
 #define QO_TERM_NODES(t)	(t)->nodes
 #define QO_TERM_SEGS(t)		(t)->segments
 #define QO_TERM_SELECTIVITY(t)	(t)->selectivity
+#define QO_TERM_HEAD_MCV_MAX_FREQUENCY(t)	(t)->head_mcv_max_frequency
+#define QO_TERM_TAIL_MCV_MAX_FREQUENCY(t)	(t)->tail_mcv_max_frequency
 #define QO_TERM_RANK(t)		(t)->rank
 #define QO_TERM_HEAD(t)		(t)->head
 #define QO_TERM_TAIL(t)		(t)->tail

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -51,6 +51,8 @@
 #include "network_interface_cl.h"
 #include "dbtype.h"
 #include "regu_var.hpp"
+#include "query_planner_internal.h"
+#include "query_planner_constants.h"
 #include "histogram_cl.hpp"
 
 #define TEST_DUMP_PLAN_SCAN_COST 0
@@ -167,19 +169,30 @@ static void qo_follow_walk (QO_PLAN *, void (*)(QO_PLAN *, void *), void *, void
 
 static void qo_plan_compute_cost (QO_PLAN *);
 static void qo_plan_compute_subquery_cost (PT_NODE *, double *, double *);
+static double qo_sum_bitset_term_cost_weights (QO_ENV *, BITSET *);
 static void qo_sscan_cost (QO_PLAN *);
+static void qo_apply_scan_term_cpu_overhead (QO_PLAN *);
 static void qo_iscan_cost (QO_PLAN *);
 static void qo_sort_cost (QO_PLAN *);
+static bool qo_can_apply_limit_card (QO_ENV *);
+static double qo_estimate_ndv (double N, double p, double n);
+static double qo_get_join_term_cost_weight (QO_TERM *);
+static double qo_sum_join_term_cost_weights (QO_ENV *, BITSET *);
+static double qo_get_nljoin_term_cpu_overhead (QO_PLAN *, double);
+static void qo_accumulate_memoize_outer_distinct_keys (QO_PLAN *, BITSET *, double, double *);
+static double qo_estimate_memoize_outer_distinct_keys (QO_PLAN *, double);
+static bool qo_is_memoize_favorable_plan (QO_PLAN *, double, double *);
+static void qo_get_non_unique_residual_lookup_costs (QO_PLAN *, double, double *, double *);
 static void qo_mjoin_cost (QO_PLAN *);
 static void qo_nljoin_cost (QO_PLAN *);
 static void qo_hjoin_cost (QO_PLAN *);
 static void qo_follow_cost (QO_PLAN *);
 static void qo_worst_cost (QO_PLAN *);
 static void qo_zero_cost (QO_PLAN *);
+static double qo_get_term_cost_weight (QO_TERM *);
 
 static void qo_estimate_ngroups (QO_PLAN *, SORT_TYPE);
 static int qo_get_group_ndv (QO_PLAN *, SORT_TYPE);
-static double qo_estimate_ndv (double N, double p, double n);
 
 static QO_PLAN *qo_top_plan_new (QO_PLAN *);
 
@@ -207,7 +220,8 @@ static double planner_nodeset_join_cost (QO_PLANNER *, BITSET *);
 static void planner_permutate (QO_PLANNER *, QO_PARTITION *, PT_HINT_ENUM, QO_NODE *, BITSET *, BITSET *, BITSET *,
 			       BITSET *, BITSET *, BITSET *, BITSET *, int, int *);
 
-static QO_PLAN *qo_find_best_nljoin_inner_plan_on_info (QO_PLAN *, QO_INFO *, JOIN_TYPE, int);
+static QO_PLAN *qo_find_best_nljoin_inner_plan_on_info (QO_PLAN *, QO_INFO *, JOIN_TYPE, BITSET *, BITSET *,
+							BITSET *, int);
 static QO_PLAN *qo_find_best_plan_on_info (QO_INFO *, QO_EQCLASS *, double);
 static bool qo_check_new_best_plan_on_info (QO_INFO *, QO_PLAN *);
 static int qo_check_plan_on_info (QO_INFO *, QO_PLAN *);
@@ -428,32 +442,8 @@ QO_PLAN_VTBL *all_vtbls[] = {
   &qo_worst_plan_vtbl
 };
 
-static double qo_or_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel);
-
-static double qo_and_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel);
-
-static double qo_not_selectivity (QO_ENV * env, double sel);
-
-static double qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static double qo_comp_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static double qo_between_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static double qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static double qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static double qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr);
-
-static int qo_index_cardinality (QO_ENV * env, PT_NODE * attr);
 static int qo_index_cardinality_with_dedup (QO_ENV * env, PT_NODE * attr, BITSET * seg_bitset);
 
-/*
- * log3 () -
- *   return:
- *   n(in):
- */
 static double
 log3 (double n)
 {
@@ -840,6 +830,22 @@ qo_plan_compute_subquery_cost (PT_NODE * subquery, double *subq_cpu_cost, double
     }
 
   return;
+}
+
+static double
+qo_sum_bitset_term_cost_weights (QO_ENV * env, BITSET * terms)
+{
+  BITSET_ITERATOR iter;
+  int t;
+  double sum = 0.0;
+
+  for (t = bitset_iterate (terms, &iter); t != -1; t = bitset_next_member (&iter))
+    {
+      QO_TERM *term = QO_ENV_TERM (env, t);
+      sum += qo_get_term_cost_weight (term);
+    }
+
+  return sum;
 }
 
 /*
@@ -1683,7 +1689,6 @@ qo_seq_scan_new (QO_INFO * info, QO_NODE * node)
   return plan;
 }
 
-
 /*
  * qo_sscan_cost () -
  *   return:
@@ -1693,10 +1698,16 @@ static void
 qo_sscan_cost (QO_PLAN * planp)
 {
   QO_NODE *nodep;
+  double extra_weight = 0.0;
+  double scan_rows;
 
   nodep = planp->plan_un.scan.node;
   planp->fixed_cpu_cost = 0.0;
   planp->fixed_io_cost = 0.0;
+
+  scan_rows = MAX (1, QO_NODE_NCARD (nodep));
+  planp->info->scan_rows = scan_rows;
+
   if (QO_NODE_NCARD (nodep) == 0)
     {
       planp->variable_cpu_cost = 1.0 * (double) QO_CPU_WEIGHT;
@@ -1705,8 +1716,11 @@ qo_sscan_cost (QO_PLAN * planp)
     {
       planp->variable_cpu_cost = (double) QO_NODE_NCARD (nodep) * (double) QO_CPU_WEIGHT;
     }
+
+  extra_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(QO_NODE_SARGS (nodep)));
+
+  planp->variable_cpu_cost += scan_rows * QO_CPU_WEIGHT * extra_weight * QO_SSCAN_FILTER_CPU_FACTOR;
   planp->variable_io_cost = (double) QO_NODE_TCARD (nodep);
-  planp->info->scan_rows = MAX (1, QO_NODE_NCARD (nodep));
 
 #if TEST_DUMP_PLAN_SCAN_COST
   fprintf (stdout, "\nSequential Scan Cost: \n");
@@ -1724,6 +1738,24 @@ qo_sscan_cost (QO_PLAN * planp)
     }
   fprintf (stdout, "\n");
 #endif /* TEST_DUMP_PLAN_SCAN_COST */
+}
+
+static void
+qo_apply_scan_term_cpu_overhead (QO_PLAN * planp)
+{
+  double scan_rows = MAX (1.0, planp->info->scan_rows);
+  double range_weight = 0.0;
+  double key_filter_weight = 0.0;
+  double data_filter_weight = 0.0;
+
+  range_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(planp->plan_un.scan.terms));
+
+  key_filter_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(planp->plan_un.scan.kf_terms));
+
+  data_filter_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(planp->sarged_terms));
+
+  planp->variable_cpu_cost +=
+    scan_rows * QO_CPU_WEIGHT * (1.2 * range_weight + 1.0 * key_filter_weight + 0.8 * data_filter_weight);
 }
 
 /*
@@ -2233,6 +2265,7 @@ qo_iscan_cost (QO_PLAN * planp)
   planp->variable_cpu_cost = (leaf_access + heap_access) * (double) QO_CPU_WEIGHT;
   planp->variable_io_cost = object_IO;
   planp->info->scan_rows = MAX (1, (double) QO_NODE_NCARD (nodep) * sel * filter_sel);
+  qo_apply_scan_term_cpu_overhead (planp);
 
 #if TEST_DUMP_PLAN_SCAN_COST
   fprintf (stdout, "\nIndex Scan Cost: \n");
@@ -3287,6 +3320,336 @@ qo_can_apply_limit_card (QO_ENV * env)
   return true;
 }
 
+static double
+qo_get_join_term_cost_weight (QO_TERM * term)
+{
+  PT_NODE *expr;
+
+  if (term == NULL)
+    {
+      return QO_COST_WEIGHT_JOIN_DEFAULT;
+    }
+
+  expr = QO_TERM_PT_EXPR (term);
+  if (expr == NULL || expr->node_type != PT_EXPR)
+    {
+      return QO_COST_WEIGHT_JOIN_DEFAULT;
+    }
+
+  switch (expr->info.expr.op)
+    {
+    case PT_EQ:
+    case PT_NULLSAFE_EQ:
+      {
+	PT_NODE *lhs = expr->info.expr.arg1;
+
+	if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	  {
+	    return QO_COST_WEIGHT_JOIN_STRING_EQUAL;
+	  }
+	return QO_COST_WEIGHT_JOIN_DEFAULT;
+      }
+
+    case PT_LT:
+    case PT_LE:
+    case PT_GT:
+    case PT_GE:
+    case PT_BETWEEN:
+    case PT_RANGE:
+      {
+	PT_NODE *lhs = expr->info.expr.arg1;
+
+	if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	  {
+	    return QO_COST_WEIGHT_JOIN_STRING_RANGE;
+	  }
+	return QO_COST_WEIGHT_JOIN_DEFAULT;
+      }
+
+    default:
+      return QO_COST_WEIGHT_JOIN_DEFAULT;
+    }
+}
+
+static double
+qo_sum_join_term_cost_weights (QO_ENV * env, BITSET * terms)
+{
+  BITSET_ITERATOR iter;
+  int t;
+  double sum = 0.0;
+
+  if (env == NULL || terms == NULL)
+    {
+      return 0.0;
+    }
+
+  for (t = bitset_iterate (terms, &iter); t != -1; t = bitset_next_member (&iter))
+    {
+      QO_TERM *term = QO_ENV_TERM (env, t);
+      sum += qo_get_join_term_cost_weight (term);
+    }
+
+  return sum;
+}
+
+static double
+qo_get_nljoin_term_cpu_overhead (QO_PLAN * planp, double guessed_result_cardinality)
+{
+  double join_term_weight_sum = 0.0;
+
+  if (planp == NULL || planp->plan_type != QO_PLANTYPE_JOIN || planp->info == NULL || planp->info->env == NULL)
+    {
+      return 0.0;
+    }
+
+  if (guessed_result_cardinality <= 0.0)
+    {
+      return 0.0;
+    }
+
+  /*
+   * For temporary nl-join plans used only for inner-plan search,
+   * join-term bitsets may be empty even after explicit init.
+   * That is fine; the summed overhead will become 0.
+   */
+
+  if (BITSET_IS_VALID (&(planp->plan_un.join.join_terms)))
+    {
+      join_term_weight_sum += qo_sum_join_term_cost_weights (planp->info->env, &(planp->plan_un.join.join_terms));
+    }
+  if (BITSET_IS_VALID (&(planp->plan_un.join.during_join_terms)))
+    {
+      join_term_weight_sum +=
+	qo_sum_join_term_cost_weights (planp->info->env, &(planp->plan_un.join.during_join_terms));
+    }
+
+  if (join_term_weight_sum <= 0.0)
+    {
+      return 0.0;
+    }
+
+  return guessed_result_cardinality * QO_CPU_WEIGHT * 0.5 * join_term_weight_sum;
+}
+
+static void
+qo_accumulate_memoize_outer_distinct_keys (QO_PLAN * planp, BITSET * terms, double guessed_outer_cardinality,
+					   double *best_ndvp)
+{
+  QO_PLAN *inner;
+  BITSET_ITERATOR iter;
+  int t;
+
+  if (planp == NULL || planp->plan_type != QO_PLANTYPE_JOIN || !QO_IS_NL_JOIN (planp)
+      || terms == NULL || best_ndvp == NULL || !BITSET_IS_VALID (terms))
+    {
+      return;
+    }
+
+  inner = planp->plan_un.join.inner;
+  if (inner == NULL || inner->info == NULL || !qo_is_iscan (inner))
+    {
+      return;
+    }
+
+  for (t = bitset_iterate (terms, &iter); t != -1; t = bitset_next_member (&iter))
+    {
+      QO_TERM *term = QO_ENV_TERM (planp->info->env, t);
+      PT_NODE *expr, *lhs, *rhs, *outer_attr;
+      QO_NODE *lhs_node, *rhs_node;
+      PT_NODE *dummy;
+      int ndv;
+
+      if (term == NULL || !QO_TERM_IS_FLAGED (term, QO_TERM_EQUAL_OP))
+	{
+	  continue;
+	}
+
+      expr = QO_TERM_PT_EXPR (term);
+      if (expr == NULL || expr->node_type != PT_EXPR || expr->info.expr.op != PT_EQ)
+	{
+	  continue;
+	}
+
+      lhs = expr->info.expr.arg1;
+      rhs = expr->info.expr.arg2;
+      if (lhs == NULL || rhs == NULL || qo_classify (lhs) != PC_ATTR || qo_classify (rhs) != PC_ATTR)
+	{
+	  continue;
+	}
+
+      lhs_node = lookup_node (lhs, QO_TERM_ENV (term), &dummy);
+      rhs_node = lookup_node (rhs, QO_TERM_ENV (term), &dummy);
+      if (lhs_node == NULL || rhs_node == NULL)
+	{
+	  continue;
+	}
+
+      if (BITSET_MEMBER (inner->info->nodes, QO_NODE_IDX (lhs_node)))
+	{
+	  outer_attr = rhs;
+	}
+      else if (BITSET_MEMBER (inner->info->nodes, QO_NODE_IDX (rhs_node)))
+	{
+	  outer_attr = lhs;
+	}
+      else
+	{
+	  continue;
+	}
+
+      ndv = qo_index_cardinality (QO_TERM_ENV (term), outer_attr);
+      if (ndv > 0)
+	{
+	  double clamped_ndv = MIN (guessed_outer_cardinality, (double) ndv);
+	  *best_ndvp = (*best_ndvp <= 0.0) ? clamped_ndv : MIN (guessed_outer_cardinality, *best_ndvp * clamped_ndv);
+	}
+    }
+}
+
+static double
+qo_estimate_memoize_outer_distinct_keys (QO_PLAN * planp, double guessed_outer_cardinality)
+{
+  double best_ndv = 0.0;
+
+  if (planp == NULL || planp->plan_type != QO_PLANTYPE_JOIN || !QO_IS_NL_JOIN (planp))
+    {
+      return guessed_outer_cardinality;
+    }
+
+  qo_accumulate_memoize_outer_distinct_keys (planp, &(planp->plan_un.join.join_terms), guessed_outer_cardinality,
+					     &best_ndv);
+  qo_accumulate_memoize_outer_distinct_keys (planp, &(planp->plan_un.join.during_join_terms),
+					     guessed_outer_cardinality, &best_ndv);
+
+  return (best_ndv > 0.0) ? MAX (1.0, best_ndv) : guessed_outer_cardinality;
+}
+
+static bool
+qo_is_memoize_favorable_plan (QO_PLAN * planp, double guessed_outer_cardinality, double *effective_outer_cardinality)
+{
+  QO_PLAN *inner;
+  QO_INDEX_ENTRY *index_entryp;
+  double inner_cardinality;
+  double miss_cardinality;
+  double outer_distinct_keys;
+  bool unique_lookup;
+
+  if (effective_outer_cardinality != NULL)
+    {
+      *effective_outer_cardinality = guessed_outer_cardinality;
+    }
+
+  if (planp == NULL || planp->plan_type != QO_PLANTYPE_JOIN || !QO_IS_NL_JOIN (planp))
+    {
+      return false;
+    }
+
+  inner = planp->plan_un.join.inner;
+  if (inner == NULL || inner->info == NULL || !qo_is_iscan (inner) || inner->plan_un.scan.index == NULL
+      || inner->plan_un.scan.index->head == NULL)
+    {
+      return false;
+    }
+
+  index_entryp = inner->plan_un.scan.index->head;
+  unique_lookup =
+    qo_is_all_unique_index_columns_are_equi_terms (inner)
+    || (index_entryp->constraints != NULL && SM_IS_CONSTRAINT_UNIQUE_FAMILY (index_entryp->constraints->type)
+	&& (BITSET_IS_VALID (&(planp->plan_un.join.join_terms))
+	    || BITSET_IS_VALID (&(planp->plan_un.join.during_join_terms))));
+
+  if (!unique_lookup)
+    {
+      return false;
+    }
+
+  inner_cardinality = MAX (1.0, inner->info->cardinality);
+  if (guessed_outer_cardinality <= inner_cardinality)
+    {
+      return false;
+    }
+
+  if (effective_outer_cardinality != NULL)
+    {
+      outer_distinct_keys = qo_estimate_memoize_outer_distinct_keys (planp, guessed_outer_cardinality);
+      miss_cardinality = MIN (guessed_outer_cardinality, outer_distinct_keys);
+      *effective_outer_cardinality =
+	miss_cardinality + (guessed_outer_cardinality - miss_cardinality) * QO_NLJOIN_MEMOIZE_HIT_COST_RATIO;
+    }
+
+  return true;
+}
+
+static void
+qo_get_non_unique_residual_lookup_costs (QO_PLAN * planp, double outer_cardinality, double *cpu_costp, double *io_costp)
+{
+  QO_PLAN *inner;
+  QO_INDEX_ENTRY *index_entryp;
+  QO_ATTR_CUM_STATS *cum_statsp;
+  double rows_per_lookup;
+  double residual_weight;
+  double heap_io_per_lookup;
+  int pkeys_num;
+
+  if (cpu_costp != NULL)
+    {
+      *cpu_costp = 0.0;
+    }
+  if (io_costp != NULL)
+    {
+      *io_costp = 0.0;
+    }
+
+  if (planp == NULL || planp->plan_type != QO_PLANTYPE_JOIN || !QO_IS_NL_JOIN (planp))
+    {
+      return;
+    }
+
+  inner = planp->plan_un.join.inner;
+  if (inner == NULL || inner->info == NULL || !qo_is_iscan (inner) || inner->plan_un.scan.index == NULL
+      || inner->plan_un.scan.index->head == NULL || bitset_is_empty (&(inner->sarged_terms)))
+    {
+      return;
+    }
+
+  index_entryp = inner->plan_un.scan.index->head;
+  if (index_entryp->constraints != NULL && SM_IS_CONSTRAINT_UNIQUE_FAMILY (index_entryp->constraints->type))
+    {
+      return;
+    }
+
+  cum_statsp = &(inner->plan_un.scan.index->cum_stats);
+  pkeys_num = MIN (index_entryp->col_num, cum_statsp->pkeys_size);
+  if (pkeys_num <= 0 || cum_statsp->pkeys == NULL || cum_statsp->pkeys[0] <= 0)
+    {
+      return;
+    }
+
+  rows_per_lookup = (double) QO_NODE_NCARD (inner->plan_un.scan.node) / (double) cum_statsp->pkeys[0];
+  if (rows_per_lookup <= 1.0)
+    {
+      return;
+    }
+
+  residual_weight = qo_sum_bitset_term_cost_weights (inner->info->env, &(inner->sarged_terms));
+  if (cpu_costp != NULL && residual_weight > 0.0)
+    {
+      /*
+       * A non-unique lookup reads candidate tuples before residual predicates
+       * can discard them. Charge both tuple visitation and residual predicate
+       * evaluation per candidate row.
+       */
+      *cpu_costp =
+	outer_cardinality * rows_per_lookup * (QO_COST_WEIGHT_PRED_DEFAULT + residual_weight) * QO_CPU_WEIGHT;
+    }
+
+  if (io_costp != NULL && !qo_is_index_covering_scan (inner))
+    {
+      heap_io_per_lookup = rows_per_lookup / (double) ISCAN_OID_ACCESS_OVERHEAD;
+      *io_costp = outer_cardinality * heap_io_per_lookup * (1 - ISCAN_IO_HIT_RATIO);
+    }
+}
+
 /*
  * qo_nljoin_cost () -
  *   return:
@@ -3298,6 +3661,8 @@ qo_nljoin_cost (QO_PLAN * planp)
   QO_PLAN *inner, *outer;
   double inner_io_cost, inner_cpu_cost, outer_io_cost, outer_cpu_cost;
   double guessed_result_cardinality, limit_val, outer_card;
+  double inner_cost_cardinality;
+  double non_unique_residual_lookup_cpu_cost, non_unique_residual_lookup_io_cost;
 
   inner = planp->plan_un.join.inner;
 
@@ -3359,12 +3724,19 @@ qo_nljoin_cost (QO_PLAN * planp)
     {
       guessed_result_cardinality = (outer->info)->cardinality;
     }
-  inner_cpu_cost = guessed_result_cardinality * inner->variable_cpu_cost;
+
+  inner_cost_cardinality = guessed_result_cardinality;
+  (void) qo_is_memoize_favorable_plan (planp, guessed_result_cardinality, &inner_cost_cardinality);
+  qo_get_non_unique_residual_lookup_costs (planp, inner_cost_cardinality, &non_unique_residual_lookup_cpu_cost,
+					   &non_unique_residual_lookup_io_cost);
+
+  inner_cpu_cost = inner_cost_cardinality * inner->variable_cpu_cost + non_unique_residual_lookup_cpu_cost;
 
   /* inner side IO cost of nested-loop block join */
   if (qo_is_iscan (inner))
     {
-      inner_io_cost = guessed_result_cardinality * inner->variable_io_cost * (1 - ISCAN_IO_HIT_RATIO);
+      inner_io_cost = inner_cost_cardinality * inner->variable_io_cost * (1 - ISCAN_IO_HIT_RATIO);
+      inner_io_cost += non_unique_residual_lookup_io_cost;
     }
   else
     {
@@ -3417,6 +3789,11 @@ qo_nljoin_cost (QO_PLAN * planp)
     /* subq cost is already included in the inner. so add it for the cardinality excluded due to ISCAN_IO_HIT_RATIO. */
     planp->variable_cpu_cost += guessed_result_cardinality * ISCAN_IO_HIT_RATIO * subq_cpu_cost;
     planp->variable_io_cost += guessed_result_cardinality * ISCAN_IO_HIT_RATIO * subq_io_cost;	/* assume IO as # blocks */
+
+    if (planp->info->env && BITSET_IS_VALID (&(planp->plan_un.join.join_terms)))
+      {
+	planp->variable_cpu_cost += qo_get_nljoin_term_cpu_overhead (planp, guessed_result_cardinality);
+      }
   }
 
 #if TEST_DUMP_PLAN_JOIN_COST
@@ -3991,7 +4368,6 @@ qo_zero_cost (QO_PLAN * planp)
   planp->variable_io_cost = 0.0;
 }
 
-
 /*
  * qo_plan_order_by () -
  *   return:
@@ -4103,7 +4479,6 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
   bf = b->fixed_cpu_cost + b->fixed_io_cost;
   ba = b->variable_cpu_cost + b->variable_io_cost;
 
-  /* Check if RBO is needed */
   ta = af + aa;
   tb = bf + ba;
   if (ta > 0 && tb > 0 && QO_PLAN_HAS_LIMIT (a) && QO_PLAN_HAS_LIMIT (b))
@@ -5922,7 +6297,6 @@ qo_check_new_best_plan_on_info (QO_INFO * info, QO_PLAN * plan)
 static int
 qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
 {
-  QO_INFO *best_info;
   QO_EQCLASS *plan_order;
   QO_PLAN_COMPARE_RESULT cmp;
   bool found_new_best;
@@ -5934,7 +6308,6 @@ qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
 
   /* init */
   found_new_best = false;
-  best_info = info->planner->best_info;
   plan_order = plan->order;
 
   /* if the plan is of type QO_SCANMETHOD_INDEX_ORDERBY_SCAN but it doesn't skip the orderby, we release the plan. */
@@ -5950,25 +6323,6 @@ qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
     {
       qo_plan_release (plan);
       return 0;
-    }
-
-  /*
-   * If the cost of the new Plan already exceeds the cost of the best
-   * known solution with the same order, there is no point in
-   * remembering the new plan.
-   */
-  if (best_info)
-    {
-      cmp =
-	qo_cmp_planvec (plan_order ==
-			QO_UNORDERED ? &best_info->best_no_order : &best_info->planvec[QO_EQCLASS_IDX (plan_order)],
-			plan);
-      /* cmp : PLAN_COMP_UNK, PLAN_COMP_LT, PLAN_COMP_EQ, PLAN_COMP_GT */
-      if (cmp == PLAN_COMP_LT || cmp == PLAN_COMP_EQ)
-	{
-	  qo_plan_release (plan);
-	  return 0;
-	}
     }
 
   /*
@@ -6021,7 +6375,8 @@ qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
  *   idx_join_plan_n(in):
  */
 static QO_PLAN *
-qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TYPE join_type, int idx_join_plan_n)
+qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TYPE join_type, BITSET * join_terms,
+					BITSET * duj_terms, BITSET * afj_terms, int idx_join_plan_n)
 {
   QO_PLANVEC *pv;
   QO_PLAN *temp, *best_plan, *inner;
@@ -6048,6 +6403,17 @@ qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TY
   temp->plan_type = QO_PLANTYPE_JOIN;
   temp->plan_un.join.join_type = join_type;	/* set nl-join type */
   temp->plan_un.join.outer = outer;	/* set outer */
+
+  bitset_init (&(temp->plan_un.join.join_terms), info->env);
+  bitset_init (&(temp->plan_un.join.during_join_terms), info->env);
+  bitset_init (&(temp->plan_un.join.after_join_terms), info->env);
+
+  bitset_assign (&(temp->plan_un.join.join_terms), join_terms);
+  if (IS_OUTER_JOIN_TYPE (join_type))
+    {
+      bitset_assign (&(temp->plan_un.join.during_join_terms), duj_terms);
+      bitset_assign (&(temp->plan_un.join.after_join_terms), afj_terms);
+    }
 
   temp->multi_range_opt_use = PLAN_MULTI_RANGE_OPT_NO;
 
@@ -6078,6 +6444,9 @@ qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TY
   /* free temp plan */
   temp->plan_un.join.outer = NULL;
   temp->plan_un.join.inner = NULL;
+  bitset_delset (&(temp->plan_un.join.join_terms));
+  bitset_delset (&(temp->plan_un.join.during_join_terms));
+  bitset_delset (&(temp->plan_un.join.after_join_terms));
 
   qo_plan_add_to_free_list (temp, NULL);
 
@@ -6279,7 +6648,9 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
 	{
 	  goto exit;
 	}
-      inner_plan = qo_find_best_nljoin_inner_plan_on_info (outer_plan, outer, join_type, idx_join_plan_n);
+      inner_plan =
+	qo_find_best_nljoin_inner_plan_on_info (outer_plan, outer, join_type, nl_join_terms, duj_terms, afj_terms,
+						idx_join_plan_n);
       if (inner_plan == NULL)
 	{
 	  goto exit;
@@ -6313,7 +6684,9 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
 	{
 	  goto exit;
 	}
-      inner_plan = qo_find_best_nljoin_inner_plan_on_info (outer_plan, inner, join_type, idx_join_plan_n);
+      inner_plan =
+	qo_find_best_nljoin_inner_plan_on_info (outer_plan, inner, join_type, nl_join_terms, duj_terms, afj_terms,
+						idx_join_plan_n);
       if (inner_plan == NULL)
 	{
 	  goto exit;
@@ -6565,17 +6938,17 @@ qo_examine_hash_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_I
   /* A query using a predicate for an oid is rewritten as a path join query.  The path join query is executed
    * as a left outer join, so if the path join query is not executed with a follow plan, results with NULL values
    * are retrieved even if the join predicate is not satisfied.
-   * 
+   *
    *   e.g. drop table if exists t;
    *        create table t (c int) dont_reuse_oid;
    *        insert into t values (1);
    *        select dual into :dummy_oid from dual limit 1;
-   * 
+   *
    *        select * from t where t = :dummy_oid;
    *
    *        -- rewritten query
    *        select dt_1.da_2.t.c from table({:dummy_oid}) dt_1 (da_2)
-   * 
+   *
    *        -- Query plan: follow
    *        There are no results.
    *        0 row selected.
@@ -6583,7 +6956,7 @@ qo_examine_hash_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_I
    *        -- Query plan: hash-join (left outer join)
    *        c1: NULL
    *        1 row selected.
-   * 
+   *
    * This code prevents the path join query from being executed as a hash join plan rather than as a follow plan.
    */
   for (bitset_index = bitset_iterate (hash_join_terms, &bitset_iter); bitset_index != -1;
@@ -7838,7 +8211,9 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 		}
 	      else
 		{
-		  selectivity *= QO_TERM_SELECTIVITY (term);
+		  double term_sel = QO_TERM_SELECTIVITY (term);
+
+		  selectivity *= term_sel;
 		  selectivity = MAX (1.0 / MAX (cardinality, 1.0), selectivity);
 
 		  double head_factor, tail_factor;
@@ -9744,1191 +10119,12 @@ qo_combine_partitions (QO_PLANNER * planner, BITSET * reamining_subqueries)
 }
 
 /*
- * qo_expr_selectivity () -
- *   return: double
- *   env(in): optimizer environment
- *   pt_expr(in): expression to evaluate
- */
-double
-qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  double lhs_selectivity, rhs_selectivity, selectivity, total_selectivity;
-  PT_NODE *node;
-  bool not_null_calculated = false;
-
-  QO_ASSERT (env, pt_expr != NULL);
-  QO_ASSERT (env, pt_expr->node_type == PT_EXPR);
-
-  selectivity = 0.0;
-  total_selectivity = 0.0;
-
-  /* traverse OR list */
-  for (node = pt_expr; node; node = node->or_next)
-    {
-      switch (node->info.expr.op)
-	{
-	case PT_OR:
-	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
-	  rhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg2);
-	  selectivity = qo_or_selectivity (env, lhs_selectivity, rhs_selectivity);
-	  break;
-
-	case PT_AND:
-	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
-	  rhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg2);
-	  selectivity = qo_and_selectivity (env, lhs_selectivity, rhs_selectivity);
-	  break;
-
-	case PT_NOT:
-	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
-	  selectivity = qo_not_selectivity (env, lhs_selectivity);
-	  break;
-
-	case PT_EQ:
-	  selectivity = qo_equal_selectivity (env, node);
-	  break;
-
-	case PT_NE:
-	  lhs_selectivity = qo_equal_selectivity (env, node);
-	  selectivity = qo_not_selectivity (env, lhs_selectivity);
-	  break;
-
-	case PT_NULLSAFE_EQ:
-	  selectivity = qo_equal_selectivity (env, node);
-	  break;
-
-	case PT_GE:
-	case PT_GT:
-	case PT_LT:
-	case PT_LE:
-	  selectivity = qo_comp_selectivity (env, node);
-	  break;
-
-	case PT_BETWEEN:
-	  selectivity = qo_between_selectivity (env, node);
-	  break;
-
-	case PT_NOT_BETWEEN:
-	  lhs_selectivity = qo_between_selectivity (env, node);
-	  selectivity = qo_not_selectivity (env, lhs_selectivity);
-	  break;
-
-	case PT_RANGE:
-	  selectivity = qo_range_selectivity (env, node);
-	  break;
-
-	case PT_LIKE_ESCAPE:
-	  selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
-	  break;
-	case PT_LIKE:
-	  {
-	    selectivity = qo_like_selectivity (env, pt_expr);
-	    break;
-	  }
-	case PT_NOT_LIKE:
-	  {
-	    selectivity = 1 - qo_like_selectivity (env, pt_expr);
-	    break;
-	  }
-	case PT_SETNEQ:
-	case PT_SETEQ:
-	case PT_SUPERSETEQ:
-	case PT_SUPERSET:
-	case PT_SUBSET:
-	case PT_SUBSETEQ:
-	case PT_IS:
-	case PT_XOR:
-	  selectivity = DEFAULT_SELECTIVITY;
-	  break;
-
-	case PT_IS_NOT:
-	  selectivity = qo_not_selectivity (env, DEFAULT_SELECTIVITY);
-	  break;
-
-	case PT_EQ_SOME:
-	case PT_NE_SOME:
-	case PT_GE_SOME:
-	case PT_GT_SOME:
-	case PT_LT_SOME:
-	case PT_LE_SOME:
-	case PT_EQ_ALL:
-	case PT_NE_ALL:
-	case PT_GE_ALL:
-	case PT_GT_ALL:
-	case PT_LT_ALL:
-	case PT_LE_ALL:
-	case PT_IS_IN:
-	  selectivity = qo_all_some_in_selectivity (env, node);
-	  break;
-
-	case PT_IS_NOT_IN:
-	  lhs_selectivity = qo_all_some_in_selectivity (env, node);
-	  selectivity = qo_not_selectivity (env, lhs_selectivity);
-	  break;
-
-	case PT_IS_NULL:
-	  if (pt_expr->info.expr.arg1->node_type == PT_NAME && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
-	    {
-	      selectivity = pt_expr->info.expr.arg1->info.name.null_frequency;
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_NULL_SELECTIVITY;
-	    }
-	  not_null_calculated = true;
-	  break;
-
-	case PT_IS_NOT_NULL:
-	  if (pt_expr->info.expr.arg1->node_type == PT_NAME && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
-	    {
-	      selectivity = pt_expr->info.expr.arg1->info.name.null_frequency;
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_NULL_SELECTIVITY;
-	    }
-	  selectivity = 1 - selectivity;
-	  not_null_calculated = true;
-	  break;
-
-	case PT_EXISTS:
-	  selectivity = DEFAULT_EXISTS_SELECTIVITY;	/* make a guess */
-	  break;
-
-	default:
-	  break;
-	}
-
-      if (!not_null_calculated)
-	{
-	  if (pt_expr->info.expr.arg1 && pt_expr->info.expr.arg1->node_type == PT_NAME
-	      && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
-	    {
-	      selectivity = selectivity * (1 - pt_expr->info.expr.arg1->info.name.null_frequency);
-	    }
-	  if (pt_expr->info.expr.arg2 && pt_expr->info.expr.arg2->node_type == PT_NAME
-	      && pt_expr->info.expr.arg2->info.name.null_frequency >= 0.0)
-	    {
-	      selectivity = selectivity * (1 - pt_expr->info.expr.arg2->info.name.null_frequency);
-	    }
-	}
-
-      total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);
-      total_selectivity = MAX (total_selectivity, 0.0);
-      total_selectivity = MIN (total_selectivity, 1.0);
-    }
-
-  return total_selectivity;
-}
-
-static double
-qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PT_NODE *lhs, *rhs;
-  DB_VALUE *host_var = NULL;
-  PRED_CLASS pc_lhs, pc_rhs;
-
-  double selectivity;
-  double total_selectivity = 0.0;
-
-  PT_NODE *like_node;
-
-  for (like_node = pt_expr; like_node; like_node = like_node->or_next)
-    {
-      bool success = false;
-
-      lhs = like_node->info.expr.arg1;
-      rhs = like_node->info.expr.arg2;
-
-      if (lhs && rhs)
-	{
-	  pc_lhs = qo_classify (lhs);
-	  pc_rhs = qo_classify (rhs);
-
-	  if (pc_lhs == PC_ATTR)
-	    {
-	      if (pc_rhs == PC_CONST)
-		{
-		  host_var = &rhs->info.value.db_value;
-		}
-	      else if (pc_rhs == PC_HOST_VAR)
-		{
-		  host_var = &env->parser->host_variables[rhs->info.host_var.index];
-		}
-
-	      histogram_get_like_selectivity (lhs, host_var, &selectivity, &success);
-
-	      if (!success)
-		{
-		  selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
-		}
-	    }
-	  else
-	    {
-	      selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
-	    }
-
-	  total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);
-	  total_selectivity = MAX (total_selectivity, 0.0);
-	  total_selectivity = MIN (total_selectivity, 1.0);
-	}
-
-    }
-
-
-  return total_selectivity;
-}
-
-/*
- * qo_or_selectivity () - Calculate the selectivity of an OR expression
- *                        from the selectivities of the lhs and rhs
- *   return: double
- *   env(in):
- *   lhs_sel(in):
- *   rhs_sel(in):
- */
-static double
-qo_or_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel)
-{
-  double result;
-
-  QO_ASSERT (env, lhs_sel >= 0.0);
-  QO_ASSERT (env, lhs_sel <= 1.0);
-  QO_ASSERT (env, rhs_sel >= 0.0);
-  QO_ASSERT (env, rhs_sel <= 1.0);
-
-  result = lhs_sel + rhs_sel - (lhs_sel * rhs_sel);
-
-  return result;
-}
-
-/*
- * qo_and_selectivity () -
- *   return:
- *   env(in):
- *   lhs_sel(in):
- *   rhs_sel(in):
- */
-static double
-qo_and_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel)
-{
-  double result;
-
-  QO_ASSERT (env, lhs_sel >= 0.0);
-  QO_ASSERT (env, lhs_sel <= 1.0);
-  QO_ASSERT (env, rhs_sel >= 0.0);
-  QO_ASSERT (env, rhs_sel <= 1.0);
-
-  result = lhs_sel * rhs_sel;
-
-  return result;
-}
-
-/*
- * qo_not_selectivity () - Calculate the selectivity of a not expresssion
- *   return: double
- *   env(in):
- *   sel(in):
- */
-static double
-qo_not_selectivity (QO_ENV * env, double sel)
-{
-  QO_ASSERT (env, sel >= 0.0);
-  QO_ASSERT (env, sel <= 1.0);
-
-  return 1.0 - sel;
-}
-
-/*
- * qo_equal_selectivity () - Compute the selectivity of an equality predicate
- *   return: double
- *   env(in):
- *   pt_expr(in):
- *
- * Note: This uses the System R algorithm
- */
-static double
-qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PT_NODE *lhs, *rhs, *multi_attr;
-  DB_VALUE *host_var;
-  PRED_CLASS pc_lhs, pc_rhs;
-  int lhs_icard, rhs_icard, icard;
-  double selectivity;
-
-  lhs = pt_expr->info.expr.arg1;
-  rhs = pt_expr->info.expr.arg2;
-
-  /* the class of lhs and rhs */
-  pc_lhs = qo_classify (lhs);
-  pc_rhs = qo_classify (rhs);
-
-  selectivity = DEFAULT_EQUAL_SELECTIVITY;
-
-  bool success = false;
-
-  switch (pc_lhs)
-    {
-    case PC_ATTR:
-
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  /* attr = attr */
-
-	  /* check for indexes on either of the attributes */
-	  lhs_icard = qo_index_cardinality (env, lhs);
-	  rhs_icard = qo_index_cardinality (env, rhs);
-
-	  icard = MAX (lhs_icard, rhs_icard);
-	  if (icard != 0)
-	    {
-	      selectivity = (1.0 / icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
-	    }
-
-	  /* TODO: add histogram selectivity */
-	  break;
-
-	case PC_CONST:
-	case PC_HOST_VAR:
-	  if (pc_rhs == PC_HOST_VAR)
-	    {
-	      host_var = &env->parser->host_variables[rhs->info.host_var.index];
-	    }
-	  else
-	    {
-	      host_var = &rhs->info.value.db_value;
-	    }
-	  histogram_get_equal_selectivity (lhs, host_var, &selectivity, &success);
-	  if (success)
-	    {
-	      break;
-	    }
-	  [[fallthrough]];
-
-	case PC_SUBQUERY:
-	case PC_SET:
-	case PC_OTHER:
-	  /* attr = const */
-
-	  /* check for index on the attribute.  NOTE: For an equality predicate, we treat subqueries as constants. */
-	  lhs_icard = qo_index_cardinality (env, lhs);
-	  if (lhs_icard != 0)
-	    {
-	      selectivity = (1.0 / lhs_icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	    }
-
-	  break;
-
-	case PC_MULTI_ATTR:
-	  /* attr = (attr,attr) syntactic impossible case */
-	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	  break;
-	}
-
-      break;
-
-    case PC_CONST:
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  histogram_get_equal_selectivity (rhs, &lhs->info.value.db_value, &selectivity, &success);
-	  break;
-
-	default:
-	  break;
-	}
-      if (success)
-	{
-	  break;
-	}
-      [[fallthrough]];
-
-    case PC_HOST_VAR:
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  host_var = &env->parser->host_variables[lhs->info.host_var.index];
-	  histogram_get_equal_selectivity (rhs, host_var, &selectivity, &success);
-	  break;
-
-	default:
-	  break;
-	}
-      if (success)
-	{
-	  break;
-	}
-      [[fallthrough]];
-    case PC_SUBQUERY:
-    case PC_SET:
-    case PC_OTHER:
-
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  /* const = attr */
-
-	  /* check for index on the attribute.  NOTE: For an equality predicate, we treat subqueries as constants. */
-	  rhs_icard = qo_index_cardinality (env, rhs);
-	  if (rhs_icard != 0)
-	    {
-	      selectivity = (1.0 / rhs_icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	    }
-
-	  break;
-
-	case PC_CONST:
-	case PC_HOST_VAR:
-	case PC_SUBQUERY:
-	case PC_SET:
-	case PC_OTHER:
-	  /* const = const */
-
-	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	  break;
-
-	case PC_MULTI_ATTR:
-	  /* const = (attr,attr) */
-	  multi_attr = rhs->info.function.arg_list;
-	  rhs_icard = 0;
-	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
-	    {
-	      /* get index cardinality */
-	      icard = qo_index_cardinality (env, multi_attr);
-	      if (icard <= 0)
-		{
-		  /* the only interesting case is PT_BETWEEN_EQ_NA */
-		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
-		}
-	      if (rhs_icard == 0)
-		{
-		  /* first time */
-		  rhs_icard = icard;
-		}
-	      else
-		{
-		  rhs_icard *= icard;
-		}
-	    }
-	  if (rhs_icard != 0)
-	    {
-	      selectivity = (1.0 / rhs_icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	    }
-	  break;
-	}
-      break;
-
-    case PC_MULTI_ATTR:
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  /* (attr,attr) = attr  syntactic impossible case */
-	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	  break;
-
-	case PC_CONST:
-	case PC_HOST_VAR:
-	case PC_SUBQUERY:
-	case PC_SET:
-	case PC_OTHER:
-	  /* (attr,attr) = const */
-
-	  multi_attr = lhs->info.function.arg_list;
-	  lhs_icard = 0;
-	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
-	    {
-	      /* get index cardinality */
-	      icard = qo_index_cardinality (env, multi_attr);
-	      if (icard <= 0)
-		{
-		  /* the only interesting case is PT_BETWEEN_EQ_NA */
-		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
-		}
-	      if (lhs_icard == 0)
-		{
-		  /* first time */
-		  lhs_icard = icard;
-		}
-	      else
-		{
-		  lhs_icard *= icard;
-		}
-	    }
-	  if (lhs_icard != 0)
-	    {
-	      selectivity = (1.0 / lhs_icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	    }
-	  break;
-
-	case PC_MULTI_ATTR:
-	  /* (attr,attr) = (attr,attr) */
-	  multi_attr = lhs->info.function.arg_list;
-	  lhs_icard = 0;
-	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
-	    {
-	      /* get index cardinality */
-	      icard = qo_index_cardinality (env, multi_attr);
-	      if (icard <= 0)
-		{
-		  /* the only interesting case is PT_BETWEEN_EQ_NA */
-		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
-		}
-	      if (lhs_icard == 0)
-		{
-		  /* first time */
-		  lhs_icard = icard;
-		}
-	      else
-		{
-		  lhs_icard *= icard;
-		}
-	    }
-
-	  multi_attr = rhs->info.function.arg_list;
-	  rhs_icard = 0;
-	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
-	    {
-	      /* get index cardinality */
-	      icard = qo_index_cardinality (env, multi_attr);
-	      if (icard <= 0)
-		{
-		  /* the only interesting case is PT_BETWEEN_EQ_NA */
-		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
-		}
-	      if (rhs_icard == 0)
-		{
-		  /* first time */
-		  rhs_icard = icard;
-		}
-	      else
-		{
-		  rhs_icard *= icard;
-		}
-	    }
-
-	  icard = MAX (lhs_icard, rhs_icard);
-	  if (icard != 0)
-	    {
-	      selectivity = (1.0 / icard);
-	    }
-	  else
-	    {
-	      selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
-	    }
-	  break;
-	}
-
-      break;
-      break;
-    }
-
-  return selectivity;
-}
-
-/*
- * qo_comp_selectivity () - Compute the selectivity of a comparison predicate.
- *   return: double
- *   env(in): Pointer to an environment structure
- *   pt_expr(in): comparison expression
- *
- * Note: This uses the System R algorithm
- */
-static double
-qo_comp_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PT_NODE *lhs, *rhs, *multi_attr;
-  PRED_CLASS pc_lhs, pc_rhs;
-  DB_VALUE *rhs_db_value;
-  DB_VALUE *lhs_db_value;
-  int lhs_icard, rhs_icard, icard;
-  double selectivity;
-
-  lhs = pt_expr->info.expr.arg1;
-  rhs = pt_expr->info.expr.arg2;
-
-  /* the class of lhs and rhs */
-  pc_lhs = qo_classify (lhs);
-  pc_rhs = qo_classify (rhs);
-
-  selectivity = DEFAULT_COMP_SELECTIVITY;
-
-  bool success = false;
-  switch (pc_lhs)
-    {
-    case PC_ATTR:
-
-      switch (pc_rhs)
-	{
-	case PC_ATTR:
-	  /* TODO: add histogram selectivity */
-	  break;
-
-	case PC_CONST:
-	case PC_HOST_VAR:
-	  {
-	    if (pc_rhs == PC_HOST_VAR)
-	      {
-		rhs_db_value = &env->parser->host_variables[rhs->info.host_var.index];
-	      }
-	    else
-	      {
-		rhs_db_value = &rhs->info.value.db_value;
-	      }
-
-	    if (pt_expr->info.expr.op == PT_GE)
-	      {
-		histogram_get_comp_selectivity (lhs, rhs_db_value, true, true, &selectivity, &success);
-	      }
-	    else if (pt_expr->info.expr.op == PT_GT)
-	      {
-		histogram_get_comp_selectivity (lhs, rhs_db_value, true, false, &selectivity, &success);
-	      }
-	    else if (pt_expr->info.expr.op == PT_LE)
-	      {
-		histogram_get_comp_selectivity (lhs, rhs_db_value, false, true, &selectivity, &success);
-	      }
-	    else if (pt_expr->info.expr.op == PT_LT)
-	      {
-		histogram_get_comp_selectivity (lhs, rhs_db_value, false, false, &selectivity, &success);
-	      }
-	  }
-	  break;
-
-	default:
-	  break;
-	}
-
-      break;
-
-    case PC_CONST:
-    case PC_HOST_VAR:
-      {
-	switch (pc_rhs)
-	  {
-	  case PC_ATTR:
-	    {
-	      if (pc_lhs == PC_HOST_VAR)
-		{
-		  lhs_db_value = &env->parser->host_variables[lhs->info.host_var.index];
-		}
-	      else
-		{
-		  lhs_db_value = &lhs->info.value.db_value;
-		}
-	      if (pt_expr->info.expr.op == PT_GE)
-		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, false, &selectivity, &success);
-		}
-	      else if (pt_expr->info.expr.op == PT_GT)
-		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, true, &selectivity, &success);
-		}
-	      else if (pt_expr->info.expr.op == PT_LE)
-		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, false, &selectivity, &success);
-		}
-	      else if (pt_expr->info.expr.op == PT_LT)
-		{
-		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, true, &selectivity, &success);
-		}
-	      break;
-	    }
-	  default:
-	    break;
-	  }
-      }
-      break;
-
-    case PC_MULTI_ATTR:
-      switch (pc_rhs)
-	{
-	case PC_MULTI_ATTR:
-	  /* (attr,attr) = (attr,attr) */
-	  /* TODO: add histogram selectivity */
-	  break;
-
-	default:
-	  break;
-	}
-
-      break;
-    default:
-      break;
-    }
-
-  return success ? selectivity : DEFAULT_COMP_SELECTIVITY;
-}
-
-/*
- * qo_between_selectivity () - Compute the selectivity of a between predicate
- *   return: double
- *   env(in): Pointer to an environment structure
- *   pt_expr(in): between expression
- *
- * Note: This uses the System R algorithm
- */
-static double
-qo_between_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PT_NODE *and_node;
-
-  and_node = pt_expr->info.expr.arg2;
-
-  QO_ASSERT (env, and_node->node_type == PT_EXPR);
-  QO_ASSERT (env, pt_is_between_range_op (and_node->info.expr.op));
-
-  return DEFAULT_BETWEEN_SELECTIVITY;
-}
-
-/*
- * qo_range_selectivity () -
- *   return:
- *   env(in):
- *   pt_expr(in):
- */
-static double
-qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PT_NODE *lhs, *arg1, *arg2;
-  DB_VALUE *lhs_db_value;
-  DB_VALUE *arg1_db_value;
-  DB_VALUE *arg2_db_value;
-  PRED_CLASS pc1, pc2;
-  PRED_CLASS pc_arg1, pc_arg2;
-
-  double total_selectivity;
-  double selectivity = DEFAULT_BETWEEN_SELECTIVITY;
-  int lhs_icard = 0, rhs_icard = 0, icard = 0;
-  PT_NODE *range_node;
-  PT_OP_TYPE op_type;
-
-  lhs = pt_expr->info.expr.arg1;
-
-  pc2 = qo_classify (lhs);
-
-  /* the only interesting case is 'attr RANGE {=1,=2}' or '(attr,attr) RANGE {={..},..}' */
-  if (pc2 == PC_MULTI_ATTR)
-    {
-      lhs = lhs->info.function.arg_list;
-      lhs_icard = 0;
-      for ( /* none */ ; lhs; lhs = lhs->next)
-	{
-	  /* get index cardinality */
-	  icard = qo_index_cardinality (env, lhs);
-	  if (icard <= 0)
-	    {
-	      /* the only interesting case is PT_BETWEEN_EQ_NA */
-	      icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
-	    }
-	  if (lhs_icard == 0)
-	    {
-	      /* first time */
-	      lhs_icard = icard;
-	    }
-	  else
-	    {
-	      lhs_icard *= icard;
-	    }
-	}
-    }
-  else if (pc2 == PC_ATTR)
-    {
-      /* get index cardinality */
-      lhs_icard = qo_index_cardinality (env, lhs);
-    }
-  else
-    {
-      return DEFAULT_RANGE_SELECTIVITY;
-    }
-#if 1				/* unused anymore - DO NOT DELETE ME */
-  QO_ASSERT (env, !PT_EXPR_INFO_IS_FLAGED (pt_expr, PT_EXPR_INFO_FULL_RANGE));
-#endif
-
-  total_selectivity = 0.0;
-
-  for (range_node = pt_expr->info.expr.arg2; range_node; range_node = range_node->or_next)
-    {
-      QO_ASSERT (env, range_node->node_type == PT_EXPR);
-
-      op_type = range_node->info.expr.op;
-      QO_ASSERT (env, pt_is_between_range_op (op_type));
-
-      arg1 = range_node->info.expr.arg1;
-      arg2 = range_node->info.expr.arg2;
-
-      pc_arg1 = qo_classify (arg1);
-      pc1 = pc_arg1;
-
-      if (pc_arg1 == PC_HOST_VAR)
-	{
-	  arg1_db_value = &env->parser->host_variables[arg1->info.host_var.index];
-	}
-      else if (pc_arg1 == PC_CONST)
-	{
-	  arg1_db_value = &arg1->info.value.db_value;
-	}
-      else
-	{
-	  arg1_db_value = NULL;
-	}
-
-      if (arg2 != NULL)
-	{
-	  pc_arg2 = qo_classify (arg2);
-
-	  if (pc_arg2 == PC_HOST_VAR)
-	    {
-	      arg2_db_value = &env->parser->host_variables[arg2->info.host_var.index];
-	    }
-	  else if (pc_arg2 == PC_CONST)
-	    {
-	      arg2_db_value = &arg2->info.value.db_value;
-	    }
-	  else
-	    {
-	      arg2_db_value = NULL;
-	    }
-	}
-      else
-	{
-	  arg2_db_value = NULL;
-	}
-
-      if (op_type == PT_BETWEEN_GE_LE || op_type == PT_BETWEEN_GE_LT || op_type == PT_BETWEEN_GT_LE
-	  || op_type == PT_BETWEEN_GT_LT || op_type == PT_BETWEEN_INF_LT || op_type == PT_BETWEEN_INF_LE
-	  || op_type == PT_BETWEEN_GE_INF || op_type == PT_BETWEEN_GT_INF)
-	{
-	  double selectivity_a = 0.0, selectivity_b = 0.0, selectivity_backup = selectivity;
-	  bool success1 = false;
-	  bool success2 = false;
-	  switch (op_type)
-	    {
-	    case PT_BETWEEN_GE_LE:
-	      {
-		/* selectivity = sel_le(b) - sel_lt(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, true, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GE_LT:
-	      {
-		/* selectivity = sel_lt(b) - sel_lt(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, false, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GT_LE:
-	      {
-		/* selectivity = sel_le(b) - sel_le(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, true, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GT_LT:
-	      {
-		/* selectivity = sel_lt(b) - sel_le(a) */
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
-		histogram_get_comp_selectivity (lhs, arg2_db_value, false, false, &selectivity_b, &success2);
-		selectivity = selectivity_b - selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_INF_LT:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_INF_LE:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GT_INF:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, true, false, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    case PT_BETWEEN_GE_INF:
-	      {
-		histogram_get_comp_selectivity (lhs, arg1_db_value, true, true, &selectivity_a, &success1);
-		success2 = true;
-		selectivity = selectivity_a;
-		break;
-	      }
-	    default:
-	      break;
-	    }
-	  if (!(success1 && success2))
-	    {
-	      if (op_type == PT_BETWEEN_INF_LT || op_type == PT_BETWEEN_INF_LE || op_type == PT_BETWEEN_GE_INF
-		  || op_type == PT_BETWEEN_GT_INF)
-		{
-		  selectivity = DEFAULT_COMP_SELECTIVITY;
-		}
-	      else
-		{
-		  selectivity = DEFAULT_BETWEEN_SELECTIVITY;
-		}
-	    }
-	}
-      else if (op_type == PT_BETWEEN_EQ_NA)
-	{
-	  /* PT_BETWEEN_EQ_NA have only one argument */
-
-	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
-
-	  if (pc1 == PC_ATTR)
-	    {
-	      /* attr1 range (attr2 = ) */
-	      rhs_icard = qo_index_cardinality (env, arg1);
-
-	      icard = MAX (lhs_icard, rhs_icard);
-	      if (icard != 0)
-		{
-		  selectivity = (1.0 / icard);
-		}
-	      else
-		{
-		  selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
-		}
-	    }
-	  else
-	    {
-	      bool success = false;
-
-	      histogram_get_equal_selectivity (lhs, arg1_db_value, &selectivity, &success);
-
-	      if (!success)
-		{
-		  /* attr1 range (const = ) */
-		  if (lhs_icard != 0)
-		    {
-		      selectivity = (1.0 / lhs_icard);
-		    }
-		  else
-		    {
-		      selectivity = DEFAULT_EQUAL_SELECTIVITY;
-		    }
-		}
-	    }
-	}
-
-
-      selectivity = MAX (selectivity, 0.0);
-      selectivity = MIN (selectivity, 1.0);
-
-      total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);
-      total_selectivity = MAX (total_selectivity, 0.0);
-      total_selectivity = MIN (total_selectivity, 1.0);
-    }
-
-  return total_selectivity;
-}
-
-/*
- * qo_all_some_in_selectivity () - Compute the selectivity of an in predicate
- *   return: double
- *   env(in): Pointer to an environment structure
- *   pt_expr(in): in expression
- *
- * Note: This uses the System R algorithm
- */
-static double
-qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr)
-{
-  PRED_CLASS pc_lhs, pc_rhs;
-  double list_card = 0.0, icard = 0.0;
-  double equal_selectivity = 1.0;
-  PT_NODE *lhs;
-  PT_NODE *arg1, *arg2;
-
-  /* To avoid repeated dereferencing */
-  arg1 = pt_expr->info.expr.arg1;
-  arg2 = pt_expr->info.expr.arg2;
-
-  /* determine the class of each side of the range */
-  pc_lhs = qo_classify (arg1);
-  pc_rhs = qo_classify (arg2);
-
-  /* The only interesting cases are: attr IN set or (attr,attr) IN set or attr IN subquery */
-  if ((pc_lhs == PC_MULTI_ATTR || pc_lhs == PC_ATTR) && (pc_rhs == PC_SET || pc_rhs == PC_SUBQUERY))
-    {
-      if (pc_lhs == PC_MULTI_ATTR)
-	{
-	  for (lhs = arg1->info.function.arg_list; lhs; lhs = lhs->next)
-	    {
-	      /* get index cardinality */
-	      icard = qo_index_cardinality (env, lhs);
-	      if (icard > 0.0)
-		{
-		  equal_selectivity *= (1.0 / icard);
-		}
-	      else
-		{
-		  /* If no index, multiply by default selectivity for each attribute */
-		  equal_selectivity *= DEFAULT_EQUAL_SELECTIVITY;
-		}
-	    }
-	}
-      else if (pc_lhs == PC_ATTR)
-	{
-	  /* check for index on the attribute.  */
-	  icard = qo_index_cardinality (env, arg1);
-	  if (icard > 0.0)
-	    {
-	      equal_selectivity *= (1.0 / icard);
-	    }
-	  else
-	    {
-	      equal_selectivity = DEFAULT_EQUAL_SELECTIVITY;
-	    }
-	}
-
-      /* determine cardinality of set or subquery */
-      if (pc_rhs == PC_SET)
-	{
-	  if (pt_is_function (arg2))
-	    {
-	      list_card = pt_length_of_list (arg2->info.function.arg_list);
-	    }
-	  else
-	    {
-	      list_card = pt_length_of_list (arg2->info.value.data_value.set);
-	    }
-	}
-      else if (pc_rhs == PC_SUBQUERY)
-	{
-	  if (arg2->info.query.xasl)
-	    {
-	      list_card = ((XASL_NODE *) arg2->info.query.xasl)->cardinality;
-	    }
-	  else
-	    {
-	      /* legacy default list_card is 1000. Maybe it won't come in here */
-	      list_card = 1000.0;
-	    }
-	}
-
-      /* compute selectivity--cap at 0.5 */
-      double in_selectivity = list_card * equal_selectivity;
-      return in_selectivity > 0.5 ? 0.5 : in_selectivity;
-    }
-
-  return DEFAULT_IN_SELECTIVITY;
-}
-
-/*
- * qo_classify () - Determine which predicate class the node belongs in
- *   return: PRED_CLASS
- *   attr(in): pt node to classify
- */
-PRED_CLASS
-qo_classify (PT_NODE * attr)
-{
-  switch (attr->node_type)
-    {
-    case PT_NAME:
-    case PT_DOT_:
-      return PC_ATTR;
-
-    case PT_VALUE:
-      if (PT_IS_SET_TYPE (attr))
-	{
-	  return PC_SET;
-	}
-      else if (attr->type_enum == PT_TYPE_NULL)
-	{
-	  return PC_OTHER;
-	}
-      else
-	{
-	  return PC_CONST;
-	}
-
-    case PT_HOST_VAR:
-      return PC_HOST_VAR;
-
-    case PT_SELECT:
-    case PT_UNION:
-    case PT_INTERSECTION:
-    case PT_DIFFERENCE:
-      return PC_SUBQUERY;
-
-    case PT_FUNCTION:
-      /* (attr,attr) or (?,?) */
-      if (PT_IS_SET_TYPE (attr))
-	{
-	  PT_NODE *func_arg;
-	  func_arg = attr->info.function.arg_list;
-	  for ( /* none */ ; func_arg; func_arg = func_arg->next)
-	    {
-	      if (func_arg->node_type == PT_NAME)
-		{
-		  /* none */
-		}
-	      else if (func_arg->node_type == PT_HOST_VAR)
-		{
-		  return PC_SET;
-		}
-	      else
-		{
-		  return PC_OTHER;
-		}
-	    }
-	  return PC_MULTI_ATTR;
-	}
-      else
-	{
-	  return PC_OTHER;
-	}
-
-    case PT_EXPR:
-      if (pt_is_function_index_expression (attr))
-	{
-	  return PC_ATTR;
-	}
-      [[fallthrough]];
-    default:
-      return PC_OTHER;
-    }
-}
-
-/*
  * qo_index_cardinality () - Determine if the attribute has an index
  *   return: cardinality of the index if the index exists, otherwise return 0
  *   env(in): optimizer environment
  *   attr(in): pt node for the attribute for which we want the index cardinality
  */
-static int
+int
 qo_index_cardinality (QO_ENV * env, PT_NODE * attr)
 {
   PT_NODE *dummy;
@@ -10989,6 +10185,76 @@ qo_index_cardinality (QO_ENV * env, PT_NODE * attr)
 
   /* return number of the first partial-key of the index on the attribute shown in the expression */
   return info->cum_stats.pkeys[0];
+}
+
+/*
+ * qo_unique_index_cardinality () - Return class cardinality when attr is the
+ * only column of a normal unique-family index; otherwise 0.
+ */
+static int
+qo_unique_index_cardinality (QO_ENV * env, PT_NODE * attr)
+{
+  PT_NODE *dummy;
+  QO_NODE *nodep;
+  QO_SEGMENT *segp;
+  const char *attr_name;
+  int i;
+
+  if (attr->node_type == PT_DOT_)
+    {
+      attr = attr->info.dot.arg2;
+    }
+
+  QO_ASSERT (env, (attr->node_type == PT_NAME || pt_is_function_index_expression (attr)));
+
+  nodep = lookup_node (attr, env, &dummy);
+  if (nodep == NULL)
+    {
+      return 0;
+    }
+
+  segp = lookup_seg (nodep, attr, env);
+  if (segp == NULL || attr->info.name.meta_class == PT_RESERVED)
+    {
+      return 0;
+    }
+  attr_name = QO_SEG_NAME (segp);
+
+  if (QO_NODE_INFO (nodep) == NULL)
+    {
+      return 0;
+    }
+
+  for (i = 0; i < QO_NODE_INFO_N (nodep); i++)
+    {
+      QO_CLASS_INFO_ENTRY *class_info_entryp = &QO_NODE_INFO (nodep)->info[i];
+      SM_CLASS_CONSTRAINT *constraint;
+
+      if (class_info_entryp->smclass == NULL)
+	{
+	  continue;
+	}
+
+      for (constraint = class_info_entryp->smclass->constraints; constraint != NULL; constraint = constraint->next)
+	{
+	  int attr_id;
+
+	  if (constraint->index_status != SM_NORMAL_INDEX || !SM_IS_CONSTRAINT_UNIQUE_FAMILY (constraint->type)
+	      || constraint->attributes == NULL || constraint->attributes[0] == NULL
+	      || constraint->attributes[1] != NULL)
+	    {
+	      continue;
+	    }
+
+	  attr_id = sm_att_id (class_info_entryp->mop, attr_name);
+	  if (attr_id >= 0 && constraint->attributes[0]->id == attr_id)
+	    {
+	      return (QO_NODE_NCARD (nodep) > INT_MAX) ? INT_MAX : (int) QO_NODE_NCARD (nodep);
+	    }
+	}
+    }
+
+  return 0;
 }
 
 /*
@@ -11513,6 +10779,126 @@ qo_get_col_product_ndv (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int 
     }
 
   return tree;
+}
+
+static double
+qo_get_term_cost_weight (QO_TERM * term)
+{
+  PT_NODE *expr;
+  PT_NODE *node;
+  double total_weight = 0.0;
+
+  if (term == NULL)
+    {
+      return QO_COST_WEIGHT_PRED_DEFAULT;
+    }
+
+  expr = QO_TERM_PT_EXPR (term);
+  if (expr == NULL || expr->node_type != PT_EXPR)
+    {
+      return QO_COST_WEIGHT_PRED_DEFAULT;
+    }
+
+  for (node = expr; node != NULL; node = node->or_next)
+    {
+      double weight = QO_COST_WEIGHT_PRED_DEFAULT;
+
+      if (node->node_type != PT_EXPR)
+	{
+	  continue;
+	}
+
+      switch (node->info.expr.op)
+	{
+	case PT_EQ:
+	case PT_NE:
+	  {
+	    PT_NODE *lhs = node->info.expr.arg1;
+
+	    if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	      {
+		weight = QO_COST_WEIGHT_STRING_EQUAL;
+	      }
+	    else
+	      {
+		weight = QO_COST_WEIGHT_NUMERIC_COMPARE;
+	      }
+	    break;
+	  }
+
+	case PT_LT:
+	case PT_LE:
+	case PT_GT:
+	case PT_GE:
+	  {
+	    PT_NODE *lhs = node->info.expr.arg1;
+	    if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	      {
+		weight = QO_COST_WEIGHT_STRING_RANGE;
+	      }
+	    else
+	      {
+		weight = QO_COST_WEIGHT_NUMERIC_COMPARE;
+	      }
+	    break;
+	  }
+
+	case PT_LIKE:
+	case PT_NOT_LIKE:
+	  {
+	    PT_NODE *rhs = node->info.expr.arg2;
+
+	    if (rhs != NULL && rhs->node_type == PT_VALUE)
+	      {
+		const char *pat = db_get_string (&rhs->info.value.db_value);
+		if (pat != NULL)
+		  {
+		    const char *pct = strchr (pat, '%');
+		    const char *und = strchr (pat, '_');
+
+		    if (pct != NULL && pct[1] == '\0' && und == NULL && pct != pat)
+		      {
+			weight = QO_COST_WEIGHT_LIKE_PREFIX;
+		      }
+		    else if (pat[0] == '%' || und != NULL)
+		      {
+			weight = QO_COST_WEIGHT_LIKE_CONTAINS;
+		      }
+		    else
+		      {
+			weight = QO_COST_WEIGHT_LIKE_COMPLEX;
+		      }
+		  }
+		else
+		  {
+		    weight = QO_COST_WEIGHT_LIKE_COMPLEX;
+		  }
+	      }
+	    else
+	      {
+		weight = QO_COST_WEIGHT_LIKE_COMPLEX;
+	      }
+	    break;
+	  }
+
+	case PT_LIKE_ESCAPE:
+	  weight = QO_COST_WEIGHT_LIKE_COMPLEX;
+	  break;
+
+	default:
+	  weight = QO_COST_WEIGHT_PRED_DEFAULT;
+	  break;
+	}
+
+      total_weight += weight;
+    }
+
+  if (total_weight <= 0.0)
+    {
+      return QO_COST_WEIGHT_PRED_DEFAULT;
+    }
+
+  return total_weight;
 }
 
 /*

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -55,10 +55,7 @@
 #include "query_planner_constants.h"
 #include "histogram_cl.hpp"
 
-#define TEST_DUMP_PLAN_SCAN_COST 0
-#define TEST_DUMP_PLAN_SORT_COST 0
-#define TEST_DUMP_PLAN_JOIN_COST 0
-#define TEST_DUMP_PLAN_FOLLOW_COST 0
+/* TEST_DUMP_PLAN_*_COST come from query_planner_constants.h (single source) */
 
 #define TEST_HASH_JOIN_ENABLE 0
 #define TEST_HASH_JOIN_FORCE_ENABLE 0
@@ -2208,6 +2205,22 @@ qo_iscan_cost (QO_PLAN *planp)
 	    }
 	}
     }
+
+  /* Prefer the reservoir column NDV (QO_SEG_INFO(seg)->ndv, derived from ATTR_STATS) over the
+   * sampled B+tree key statistic (cum_stats.pkeys / keys): the B+tree sampling extrapolates distinct
+   * keys by the page ratio (btree_get_stats_with_AR_sampling) and grossly over-estimates NDV for
+   * low-NDV sorted indexes, collapsing 1/pkeys[0] so the index scan is mis-costed as nearly free.
+   * This NDV is already loaded (O(1)); only the leading single index column (index == 0) applies. */
+  if (index == 0 && index_entryp->nsegs > 0 && index_entryp->seg_idxs != NULL && index_entryp->seg_idxs[0] >= 0)
+    {
+      QO_SEGMENT *lead_segp = QO_ENV_SEG (QO_NODE_ENV (nodep), index_entryp->seg_idxs[0]);
+
+      if (lead_segp != NULL && QO_SEG_INFO (lead_segp) != NULL && QO_SEG_INFO (lead_segp)->ndv > 0)
+	{
+	  sel_limit = 1.0 / (double) QO_SEG_INFO (lead_segp)->ndv;
+	}
+    }
+
   assert (sel_limit <= 1.0);
 
   /* check lower bound */

--- a/src/optimizer/query_planner.c
+++ b/src/optimizer/query_planner.c
@@ -78,22 +78,7 @@
 #define VALID_INNER(plan)	(plan->well_rooted || \
 				 (plan->plan_type == QO_PLANTYPE_SORT))
 
-#define TEMP_SETUP_COST 5.0
-#define QO_CPU_WEIGHT 0.0025
-/* Per-OID heap-access CPU penalty for NON-covering index scans (covering scans: 0).
- * Lowered 20 -> 5 to favor index scan when low/stale leading-column NDV inflates sel via 1/pkeys[0]. TODO: per-index clustering factor. */
-#define ISCAN_OID_ACCESS_OVERHEAD 5
-#define MJ_CPU_OVERHEAD_FACTOR 20
-#define HJ_BUILD_CPU_OVERHEAD_FACTOR 30
-#define HJ_PROBE_CPU_OVERHEAD_FACTOR 20
-#define HJ_FILE_IO_WEIGHT 0.5	/* Unused */
-#define ISCAN_IO_HIT_RATIO 0.5
-#define SSCAN_DEFAULT_CARD 100
-#define GUESSED_BIND_LIMIT_CARD 2000	/* When limit is a bind variable, assume that fewer rows will be assigned. */
-
-#define RBO_CHECK_COST 50
-#define RBO_CHECK_RATIO 1.2
-#define RBO_CHECK_LIMIT_RATIO 10
+/* cost-model constants moved to query_planner_constants.h (included via query_planner_internal.h) */
 
 #define	qo_scan_walk	qo_generic_walk
 #define	qo_worst_walk	qo_generic_walk
@@ -152,9 +137,9 @@ static void qo_follow_info (QO_PLAN *, FILE *, int);
 static void qo_worst_info (QO_PLAN *, FILE *, int);
 
 void qo_plan_lite_print (QO_PLAN *, FILE *, int);
-static void qo_plan_del_ref_func (QO_PLAN * plan, void *ignore);
+static void qo_plan_del_ref_func (QO_PLAN *plan, void *ignore);
 
-static void qo_generic_walk (QO_PLAN *, void (*)(QO_PLAN *, void *), void *, void (*)(QO_PLAN *, void *), void *);
+static void qo_generic_walk (QO_PLAN *, void (*) (QO_PLAN *, void *), void *, void (*) (QO_PLAN *, void *), void *);
 static void qo_plan_print_sort_spec_helper (PT_NODE *, bool, FILE *, int);
 static void qo_plan_print_sort_spec (QO_PLAN *, FILE *, int);
 static void qo_plan_print_costs (QO_PLAN *, FILE *, int);
@@ -163,9 +148,9 @@ static void qo_plan_print_sarged_terms (QO_PLAN *, FILE *, int);
 static void qo_plan_print_outer_join_terms (QO_PLAN *, FILE *, int);
 static void qo_plan_print_subqueries (QO_PLAN *, FILE *, int);
 static void qo_plan_print_analytic_eval (QO_PLAN *, FILE *, int);
-static void qo_sort_walk (QO_PLAN *, void (*)(QO_PLAN *, void *), void *, void (*)(QO_PLAN *, void *), void *);
-static void qo_join_walk (QO_PLAN *, void (*)(QO_PLAN *, void *), void *, void (*)(QO_PLAN *, void *), void *);
-static void qo_follow_walk (QO_PLAN *, void (*)(QO_PLAN *, void *), void *, void (*)(QO_PLAN *, void *), void *);
+static void qo_sort_walk (QO_PLAN *, void (*) (QO_PLAN *, void *), void *, void (*) (QO_PLAN *, void *), void *);
+static void qo_join_walk (QO_PLAN *, void (*) (QO_PLAN *, void *), void *, void (*) (QO_PLAN *, void *), void *);
+static void qo_follow_walk (QO_PLAN *, void (*) (QO_PLAN *, void *), void *, void (*) (QO_PLAN *, void *), void *);
 
 static void qo_plan_compute_cost (QO_PLAN *);
 static void qo_plan_compute_subquery_cost (PT_NODE *, double *, double *);
@@ -212,7 +197,7 @@ static void qo_dump_planvec (QO_PLANVEC *, FILE *, int);
 static void qo_dump_info (QO_INFO *, FILE *);
 static void qo_dump_planner_info (QO_PLANNER *, QO_PARTITION *, FILE *);
 
-static void qo_get_term_hit_prob (QO_TERM * term, QO_INFO * head_info, QO_INFO * tail_info, QO_ENV * env,
+static void qo_get_term_hit_prob (QO_TERM *term, QO_INFO *head_info, QO_INFO *tail_info, QO_ENV *env,
 				  double *out_head_factor, double *out_tail_factor);
 static void planner_visit_node (QO_PLANNER *, QO_PARTITION *, PT_HINT_ENUM, QO_NODE *, QO_NODE *, BITSET *, BITSET *,
 				BITSET *, BITSET *, BITSET *, BITSET *, BITSET *, int);
@@ -221,7 +206,7 @@ static void planner_permutate (QO_PLANNER *, QO_PARTITION *, PT_HINT_ENUM, QO_NO
 			       BITSET *, BITSET *, BITSET *, BITSET *, int, int *);
 
 static QO_PLAN *qo_find_best_nljoin_inner_plan_on_info (QO_PLAN *, QO_INFO *, JOIN_TYPE, BITSET *, BITSET *,
-							BITSET *, int);
+    BITSET *, int);
 static QO_PLAN *qo_find_best_plan_on_info (QO_INFO *, QO_EQCLASS *, double);
 static bool qo_check_new_best_plan_on_info (QO_INFO *, QO_PLAN *);
 static int qo_check_plan_on_info (QO_INFO *, QO_PLAN *);
@@ -253,15 +238,15 @@ static int qo_generate_index_scan (QO_INFO *, QO_NODE *, QO_NODE_INDEX_ENTRY *, 
 static int qo_generate_loose_index_scan (QO_INFO *, QO_NODE *, QO_NODE_INDEX_ENTRY *);
 static int qo_generate_sort_limit_plan (QO_ENV *, QO_INFO *, QO_PLAN *);
 static void qo_plan_add_to_free_list (QO_PLAN *, void *ignore);
-static void qo_plans_teardown (QO_ENV * env);
-static void qo_plans_init (QO_ENV * env);
-static void qo_plan_walk (QO_PLAN *, void (*)(QO_PLAN *, void *), void *, void (*)(QO_PLAN *, void *), void *);
+static void qo_plans_teardown (QO_ENV *env);
+static void qo_plans_init (QO_ENV *env);
+static void qo_plan_walk (QO_PLAN *, void (*) (QO_PLAN *, void *), void *, void (*) (QO_PLAN *, void *), void *);
 static QO_PLAN *qo_plan_finalize (QO_PLAN *);
 static QO_PLAN *qo_plan_order_by (QO_PLAN *, QO_EQCLASS *);
 static QO_PLAN_COMPARE_RESULT qo_plan_cmp_prefer_covering_index (QO_PLAN *, QO_PLAN *);
 static void qo_plan_fprint (QO_PLAN *, FILE *, int, const char *);
 static QO_PLAN_COMPARE_RESULT qo_plan_cmp (QO_PLAN *, QO_PLAN *);
-static QO_PLAN_COMPARE_RESULT qo_plan_iscan_terms_cmp (QO_PLAN * a, QO_PLAN * b);
+static QO_PLAN_COMPARE_RESULT qo_plan_iscan_terms_cmp (QO_PLAN *a, QO_PLAN *b);
 static QO_PLAN_COMPARE_RESULT qo_index_covering_plans_cmp (QO_PLAN *, QO_PLAN *);
 static QO_PLAN_COMPARE_RESULT qo_order_by_skip_plans_cmp (QO_PLAN *, QO_PLAN *);
 static QO_PLAN_COMPARE_RESULT qo_group_by_skip_plans_cmp (QO_PLAN *, QO_PLAN *);
@@ -277,44 +262,45 @@ static QO_PLAN *qo_join_new (QO_INFO *, JOIN_TYPE, QO_JOINMETHOD, QO_PLAN *, QO_
 static QO_PLAN *qo_sort_new (QO_PLAN *, QO_EQCLASS *, SORT_TYPE);
 static QO_PLAN *qo_seq_scan_new (QO_INFO *, QO_NODE *);
 static QO_PLAN *qo_index_scan_new (QO_INFO *, QO_NODE *, QO_NODE_INDEX_ENTRY *, QO_SCANMETHOD, BITSET *, BITSET *);
-static int qo_has_is_not_null_term (QO_NODE * node);
+static int qo_has_is_not_null_term (QO_NODE *node);
 
-static bool qo_validate_index_term_notnull (QO_ENV * env, QO_INDEX_ENTRY * index_entryp);
-static bool qo_validate_index_attr_notnull (QO_ENV * env, QO_INDEX_ENTRY * index_entryp, PT_NODE * col);
-static int qo_validate_index_for_orderby (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entryp);
-static int qo_validate_index_for_groupby (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entryp);
-static PT_NODE *qo_search_isnull_key_expr (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk);
-static PT_NODE *qo_get_col_product_ndv (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk);
-static bool qo_check_orderby_skip_descending (QO_PLAN * plan);
-static bool qo_check_skip_term (QO_ENV * env, BITSET visited_segs, QO_TERM * term, BITSET * visited_terms,
-				BITSET * cur_visited_terms);
-static bool qo_check_groupby_skip_descending (QO_PLAN * plan, PT_NODE * list);
+static bool qo_validate_index_term_notnull (QO_ENV *env, QO_INDEX_ENTRY *index_entryp);
+static bool qo_validate_index_attr_notnull (QO_ENV *env, QO_INDEX_ENTRY *index_entryp, PT_NODE *col);
+static int qo_validate_index_for_orderby (QO_ENV *env, QO_NODE_INDEX_ENTRY *ni_entryp);
+static int qo_validate_index_for_groupby (QO_ENV *env, QO_NODE_INDEX_ENTRY *ni_entryp);
+static PT_NODE *qo_search_isnull_key_expr (PARSER_CONTEXT *parser, PT_NODE *tree, void *arg, int *continue_walk);
+static PT_NODE *qo_get_col_product_ndv (PARSER_CONTEXT *parser, PT_NODE *tree, void *arg, int *continue_walk);
+static bool qo_check_orderby_skip_descending (QO_PLAN *plan);
+static bool qo_check_skip_term (QO_ENV *env, BITSET visited_segs, QO_TERM *term, BITSET *visited_terms,
+				BITSET *cur_visited_terms);
+static bool qo_check_groupby_skip_descending (QO_PLAN *plan, PT_NODE *list);
 
-static int qo_walk_plan_tree (QO_PLAN * plan, QO_WALK_FUNCTION f, void *arg);
-static void qo_set_use_desc (QO_PLAN * plan);
-static int qo_set_orderby_skip (QO_PLAN * plan, void *arg);
-static int qo_unset_hint_use_desc_idx (QO_PLAN * plan, void *arg);
-static int qo_validate_indexes_for_orderby (QO_PLAN * plan, void *arg);
-static int qo_unset_multi_range_optimization (QO_PLAN * plan, void *arg);
-static bool qo_plan_is_orderby_skip_candidate (QO_PLAN * plan);
-static bool qo_is_sort_limit (QO_PLAN * plan);
-static int qo_check_like_recompile_candidate (QO_PLAN * plan, void *arg);
+static int qo_walk_plan_tree (QO_PLAN *plan, QO_WALK_FUNCTION f, void *arg);
+static void qo_set_use_desc (QO_PLAN *plan);
+static int qo_set_orderby_skip (QO_PLAN *plan, void *arg);
+static int qo_unset_hint_use_desc_idx (QO_PLAN *plan, void *arg);
+static int qo_validate_indexes_for_orderby (QO_PLAN *plan, void *arg);
+static int qo_unset_multi_range_optimization (QO_PLAN *plan, void *arg);
+static bool qo_plan_is_orderby_skip_candidate (QO_PLAN *plan);
+static bool qo_is_sort_limit (QO_PLAN *plan);
+static int qo_check_like_recompile_candidate (QO_PLAN *plan, void *arg);
 
-static json_t *qo_plan_scan_print_json (QO_PLAN * plan);
-static json_t *qo_plan_sort_print_json (QO_PLAN * plan);
-static json_t *qo_plan_join_print_json (QO_PLAN * plan);
-static json_t *qo_plan_follow_print_json (QO_PLAN * plan);
-static json_t *qo_plan_print_json (QO_PLAN * plan);
+static json_t *qo_plan_scan_print_json (QO_PLAN *plan);
+static json_t *qo_plan_sort_print_json (QO_PLAN *plan);
+static json_t *qo_plan_join_print_json (QO_PLAN *plan);
+static json_t *qo_plan_follow_print_json (QO_PLAN *plan);
+static json_t *qo_plan_print_json (QO_PLAN *plan);
 
-static void qo_plan_scan_print_text (FILE * fp, QO_PLAN * plan, int indent);
-static void qo_plan_sort_print_text (FILE * fp, QO_PLAN * plan, int indent);
-static void qo_plan_join_print_text (FILE * fp, QO_PLAN * plan, int indent);
-static void qo_plan_follow_print_text (FILE * fp, QO_PLAN * plan, int indent);
-static void qo_plan_print_text (FILE * fp, QO_PLAN * plan, int indent);
+static void qo_plan_scan_print_text (FILE *fp, QO_PLAN *plan, int indent);
+static void qo_plan_sort_print_text (FILE *fp, QO_PLAN *plan, int indent);
+static void qo_plan_join_print_text (FILE *fp, QO_PLAN *plan, int indent);
+static void qo_plan_follow_print_text (FILE *fp, QO_PLAN *plan, int indent);
+static void qo_plan_print_text (FILE *fp, QO_PLAN *plan, int indent);
 
-static bool qo_index_has_bit_attr (QO_INDEX_ENTRY * index_entryp);
+static bool qo_index_has_bit_attr (QO_INDEX_ENTRY *index_entryp);
 
-static QO_PLAN_VTBL qo_seq_scan_plan_vtbl = {
+static QO_PLAN_VTBL qo_seq_scan_plan_vtbl =
+{
   "sscan",
   qo_scan_fprint,
   qo_scan_walk,
@@ -325,7 +311,8 @@ static QO_PLAN_VTBL qo_seq_scan_plan_vtbl = {
   "Sequential scan"
 };
 
-static QO_PLAN_VTBL qo_index_scan_plan_vtbl = {
+static QO_PLAN_VTBL qo_index_scan_plan_vtbl =
+{
   "iscan",
   qo_scan_fprint,
   qo_scan_walk,
@@ -336,7 +323,8 @@ static QO_PLAN_VTBL qo_index_scan_plan_vtbl = {
   "Index scan"
 };
 
-static QO_PLAN_VTBL qo_sort_plan_vtbl = {
+static QO_PLAN_VTBL qo_sort_plan_vtbl =
+{
   "temp",
   qo_sort_fprint,
   qo_sort_walk,
@@ -347,7 +335,8 @@ static QO_PLAN_VTBL qo_sort_plan_vtbl = {
   "Sort"
 };
 
-static QO_PLAN_VTBL qo_nl_join_plan_vtbl = {
+static QO_PLAN_VTBL qo_nl_join_plan_vtbl =
+{
   "nl-join",
   qo_join_fprint,
   qo_join_walk,
@@ -358,7 +347,8 @@ static QO_PLAN_VTBL qo_nl_join_plan_vtbl = {
   "Nested-loop join"
 };
 
-static QO_PLAN_VTBL qo_idx_join_plan_vtbl = {
+static QO_PLAN_VTBL qo_idx_join_plan_vtbl =
+{
   "idx-join",
   qo_join_fprint,
   qo_join_walk,
@@ -369,7 +359,8 @@ static QO_PLAN_VTBL qo_idx_join_plan_vtbl = {
   "Correlated-index join"
 };
 
-static QO_PLAN_VTBL qo_merge_join_plan_vtbl = {
+static QO_PLAN_VTBL qo_merge_join_plan_vtbl =
+{
   "m-join",
   qo_join_fprint,
   qo_join_walk,
@@ -380,7 +371,8 @@ static QO_PLAN_VTBL qo_merge_join_plan_vtbl = {
   "Merge join"
 };
 
-static QO_PLAN_VTBL qo_hash_join_plan_vtbl = {
+static QO_PLAN_VTBL qo_hash_join_plan_vtbl =
+{
   "hash-join",
   qo_hjoin_fprint,
   qo_join_walk,
@@ -396,7 +388,8 @@ static QO_PLAN_VTBL qo_hash_join_plan_vtbl = {
   "Hash join"
 };
 
-static QO_PLAN_VTBL qo_follow_plan_vtbl = {
+static QO_PLAN_VTBL qo_follow_plan_vtbl =
+{
   "follow",
   qo_follow_fprint,
   qo_follow_walk,
@@ -407,7 +400,8 @@ static QO_PLAN_VTBL qo_follow_plan_vtbl = {
   "Object fetch"
 };
 
-static QO_PLAN_VTBL qo_set_follow_plan_vtbl = {
+static QO_PLAN_VTBL qo_set_follow_plan_vtbl =
+{
   "set_follow",
   qo_follow_fprint,
   qo_follow_walk,
@@ -418,7 +412,8 @@ static QO_PLAN_VTBL qo_set_follow_plan_vtbl = {
   "Set fetch"
 };
 
-static QO_PLAN_VTBL qo_worst_plan_vtbl = {
+static QO_PLAN_VTBL qo_worst_plan_vtbl =
+{
   "worst",
   qo_worst_fprint,
   qo_worst_walk,
@@ -429,7 +424,8 @@ static QO_PLAN_VTBL qo_worst_plan_vtbl = {
   "Bogus"
 };
 
-QO_PLAN_VTBL *all_vtbls[] = {
+QO_PLAN_VTBL *all_vtbls[] =
+{
   &qo_seq_scan_plan_vtbl,
   &qo_index_scan_plan_vtbl,
   &qo_sort_plan_vtbl,
@@ -442,7 +438,7 @@ QO_PLAN_VTBL *all_vtbls[] = {
   &qo_worst_plan_vtbl
 };
 
-static int qo_index_cardinality_with_dedup (QO_ENV * env, PT_NODE * attr, BITSET * seg_bitset);
+static int qo_index_cardinality_with_dedup (QO_ENV *env, PT_NODE *attr, BITSET *seg_bitset);
 
 static double
 log3 (double n)
@@ -458,7 +454,7 @@ log3 (double n)
  *   env(in):
  */
 static QO_PLAN *
-qo_plan_malloc (QO_ENV * env)
+qo_plan_malloc (QO_ENV *env)
 {
   QO_PLAN *plan;
 
@@ -484,8 +480,8 @@ qo_plan_malloc (QO_ENV * env)
 #endif
     }
 
-  bitset_init (&(plan->sarged_terms), env);
-  bitset_init (&(plan->subqueries), env);
+  bitset_init (& (plan->sarged_terms), env);
+  bitset_init (& (plan->subqueries), env);
 
   plan->parallel_opt_use = PLAN_PARALLEL_OPT_NO;
   plan->skip_orderby_opt = QO_PLAN_SKIP_ORDERBY_NO;
@@ -505,7 +501,7 @@ qo_plan_malloc (QO_ENV * env)
  *   term(in):
  */
 static const char *
-qo_term_string (QO_TERM * term, char *buf)
+qo_term_string (QO_TERM *term, char *buf)
 {
   char *p;
   BITSET_ITERATOR bi;
@@ -529,7 +525,7 @@ qo_term_string (QO_TERM * term, char *buf)
       sprintf (buf, "table(");
       p = buf + strlen (buf);
       separator = "";
-      for (i = bitset_iterate (&(QO_NODE_DEP_SET (QO_TERM_TAIL (term))), &bi); i != -1; i = bitset_next_member (&bi))
+      for (i = bitset_iterate (& (QO_NODE_DEP_SET (QO_TERM_TAIL (term))), &bi); i != -1; i = bitset_next_member (&bi))
 	{
 	  sprintf (p, "%s%s", separator, QO_NODE_NAME (QO_ENV_NODE (env, i)));
 	  p = buf + strlen (buf);
@@ -608,7 +604,7 @@ qo_term_string (QO_TERM * term, char *buf)
  *   and p is the estimated row count after applying all predicates.
  */
 static void
-qo_estimate_ngroups (QO_PLAN * plan, SORT_TYPE sort_type)
+qo_estimate_ngroups (QO_PLAN *plan, SORT_TYPE sort_type)
 {
   int group_ndv, estimate_ndv;
   double expected_nrows = plan->info->cardinality;
@@ -671,7 +667,7 @@ qo_estimate_ndv (double N, double p, double n)
  *   plan(in):
  */
 static int
-qo_get_group_ndv (QO_PLAN * plan, SORT_TYPE sort_type)
+qo_get_group_ndv (QO_PLAN *plan, SORT_TYPE sort_type)
 {
   PT_NODE *nodes;
   QO_ENV *env = NULL;
@@ -718,7 +714,7 @@ qo_get_group_ndv (QO_PLAN * plan, SORT_TYPE sort_type)
  *   plan(in):
  */
 static void
-qo_plan_compute_cost (QO_PLAN * plan)
+qo_plan_compute_cost (QO_PLAN *plan)
 {
   QO_ENV *env;
   QO_SUBQUERY *subq;
@@ -742,7 +738,7 @@ qo_plan_compute_cost (QO_PLAN * plan)
    * original select node.
    */
 
-  for (i = bitset_iterate (&(plan->subqueries), &iter); i != -1; i = bitset_next_member (&iter))
+  for (i = bitset_iterate (& (plan->subqueries), &iter); i != -1; i = bitset_next_member (&iter))
     {
       subq = env ? &env->subqueries[i] : NULL;
       query = subq ? subq->node : NULL;
@@ -752,7 +748,7 @@ qo_plan_compute_cost (QO_PLAN * plan)
     }
 
   /* This computes the specific cost characteristics for each plan. */
-  (*(plan->vtbl)->cost_fn) (plan);
+  (* (plan->vtbl)->cost_fn) (plan);
 
   /* Now add in the subquery costs; this cost is incurred for each row produced by this plan, so multiply it by the
    * estimated scan_rows and add it to the access cost.
@@ -772,7 +768,7 @@ qo_plan_compute_cost (QO_PLAN * plan)
  *   subq_io_cost(in):
  */
 static void
-qo_plan_compute_subquery_cost (PT_NODE * subquery, double *subq_cpu_cost, double *subq_io_cost)
+qo_plan_compute_subquery_cost (PT_NODE *subquery, double *subq_cpu_cost, double *subq_io_cost)
 {
   QO_SUMMARY *summary;
   double arg1_cpu_cost, arg1_io_cost, arg2_cpu_cost, arg2_io_cost;
@@ -833,7 +829,7 @@ qo_plan_compute_subquery_cost (PT_NODE * subquery, double *subq_cpu_cost, double
 }
 
 static double
-qo_sum_bitset_term_cost_weights (QO_ENV * env, BITSET * terms)
+qo_sum_bitset_term_cost_weights (QO_ENV *env, BITSET *terms)
 {
   BITSET_ITERATOR iter;
   int t;
@@ -858,7 +854,7 @@ qo_sum_bitset_term_cost_weights (QO_ENV * env, BITSET * terms)
  *   arg(in/out): argument to be used liberally by the callback
  */
 static int
-qo_walk_plan_tree (QO_PLAN * plan, QO_WALK_FUNCTION f, void *arg)
+qo_walk_plan_tree (QO_PLAN *plan, QO_WALK_FUNCTION f, void *arg)
 {
   int ret = NO_ERROR;
 
@@ -901,7 +897,7 @@ qo_walk_plan_tree (QO_PLAN * plan, QO_WALK_FUNCTION f, void *arg)
  * note: the function only cares about index scans and skips other plan types
  */
 static void
-qo_set_use_desc (QO_PLAN * plan)
+qo_set_use_desc (QO_PLAN *plan)
 {
   switch (plan->plan_type)
     {
@@ -941,7 +937,7 @@ qo_set_use_desc (QO_PLAN * plan)
  * arg (in)  : not used
  */
 static int
-qo_unset_multi_range_optimization (QO_PLAN * plan, void *arg)
+qo_unset_multi_range_optimization (QO_PLAN *plan, void *arg)
 {
   if (plan->multi_range_opt_use == PLAN_MULTI_RANGE_OPT_NO)
     {
@@ -985,11 +981,11 @@ qo_unset_multi_range_optimization (QO_PLAN * plan, void *arg)
  * note: the function only cares about index scans and skips other plan types
  */
 static int
-qo_set_orderby_skip (QO_PLAN * plan, void *arg)
+qo_set_orderby_skip (QO_PLAN *plan, void *arg)
 {
   if (qo_is_iscan (plan) || qo_is_iscan_from_orderby (plan))
     {
-      bool yn = *((bool *) arg);
+      bool yn = * ((bool *) arg);
       plan->plan_un.scan.index->head->orderby_skip = yn;
       plan->skip_orderby_opt = (yn) ? QO_PLAN_SKIP_ORDERBY_USE : plan->skip_orderby_opt;
     }
@@ -998,7 +994,7 @@ qo_set_orderby_skip (QO_PLAN * plan, void *arg)
 }
 
 static int
-qo_unset_hint_use_desc_idx (QO_PLAN * plan, void *arg)
+qo_unset_hint_use_desc_idx (QO_PLAN *plan, void *arg)
 {
   if (qo_is_interesting_order_scan (plan))
     {
@@ -1033,7 +1029,7 @@ qo_unset_hint_use_desc_idx (QO_PLAN * plan, void *arg)
  * arg(in): not used, must be NULL
  */
 static int
-qo_validate_indexes_for_orderby (QO_PLAN * plan, void *arg)
+qo_validate_indexes_for_orderby (QO_PLAN *plan, void *arg)
 {
   if (qo_is_iscan_from_orderby (plan))
     {
@@ -1052,7 +1048,7 @@ qo_validate_indexes_for_orderby (QO_PLAN * plan, void *arg)
  *   plan(in):
  */
 static QO_PLAN *
-qo_top_plan_new (QO_PLAN * plan)
+qo_top_plan_new (QO_PLAN *plan)
 {
   QO_ENV *env;
   PT_NODE *tree, *group_by, *order_by, *orderby_for;
@@ -1066,7 +1062,7 @@ qo_top_plan_new (QO_PLAN * plan)
     }
 
   if (plan->info == NULL	/* worst plan */
-      || (env = (plan->info)->env) == NULL || bitset_cardinality (&((plan->info)->nodes)) < env->Nnodes
+      || (env = (plan->info)->env) == NULL || bitset_cardinality (& ((plan->info)->nodes)) < env->Nnodes
       || /* sub-plan */ (tree = QO_ENV_PT_TREE (env)) == NULL
       || (parser = QO_ENV_PARSER (env)) == NULL)
     {
@@ -1078,7 +1074,8 @@ qo_top_plan_new (QO_PLAN * plan)
   plan->top_rooted = true;	/* mark as top-level plan */
 
   if (pt_is_single_tuple (QO_ENV_PARSER (env), tree))
-    {				/* one tuple plan */
+    {
+      /* one tuple plan */
       return plan;		/* do nothing */
     }
 
@@ -1194,20 +1191,23 @@ qo_top_plan_new (QO_PLAN * plan)
       if (all_distinct == PT_DISTINCT || order_by)
 	{
 	  if (plan->iscan_sort_list)
-	    {			/* need to check */
+	    {
+	      /* need to check */
 	      if (all_distinct == PT_DISTINCT)
 		{
 		  ;		/* give up */
 		}
 	      else
-		{		/* non distinct */
+		{
+		  /* non distinct */
 		  if (group_by)
 		    {
 		      /* we already removed covered ORDER BY in reduce_order_by(). so is not covered ordering */
 		      ;		/* give up; DO NOT DELETE ME - need future work */
 		    }
 		  else
-		    {		/* non group_by */
+		    {
+		      /* non group_by */
 		      if (found_instnum && (orderby_for || ordbynum_flag))
 			{
 			  /* at here, we can not merge orderby_num pred with inst_num pred */
@@ -1243,7 +1243,8 @@ qo_top_plan_new (QO_PLAN * plan)
 		}
 
 	      if (orderby_for)
-		{		/* apply inst_num filter */
+		{
+		  /* apply inst_num filter */
 		  ;		/* DO NOT DELETE ME - need future work */
 		}
 
@@ -1294,7 +1295,7 @@ qo_top_plan_new (QO_PLAN * plan)
  *   parent_data(in):
  */
 static void
-qo_generic_walk (QO_PLAN * plan, void (*child_fn) (QO_PLAN *, void *), void *child_data,
+qo_generic_walk (QO_PLAN *plan, void (*child_fn) (QO_PLAN *, void *), void *child_data,
 		 void (*parent_fn) (QO_PLAN *, void *), void *parent_data)
 {
   if (parent_fn)
@@ -1311,7 +1312,7 @@ qo_generic_walk (QO_PLAN * plan, void (*child_fn) (QO_PLAN *, void *), void *chi
  *   howfar(in):
  */
 static void
-qo_plan_print_sort_spec_helper (PT_NODE * list, bool is_iscan_asc, FILE * f, int howfar)
+qo_plan_print_sort_spec_helper (PT_NODE *list, bool is_iscan_asc, FILE *f, int howfar)
 {
   const char *prefix;
   bool is_sort_spec_asc = true;
@@ -1327,7 +1328,8 @@ qo_plan_print_sort_spec_helper (PT_NODE * list, bool is_iscan_asc, FILE * f, int
   for (; list; list = list->next)
     {
       if (list->info.sort_spec.pos_descr.pos_no < 1)
-	{			/* useless from here */
+	{
+	  /* useless from here */
 	  break;
 	}
       fputs (prefix, f);
@@ -1362,12 +1364,13 @@ qo_plan_print_sort_spec_helper (PT_NODE * list, bool is_iscan_asc, FILE * f, int
  *   howfar(in):
  */
 static void
-qo_plan_print_sort_spec (QO_PLAN * plan, FILE * f, int howfar)
+qo_plan_print_sort_spec (QO_PLAN *plan, FILE *f, int howfar)
 {
   bool is_iscan_asc = true;
 
   if (plan->top_rooted != true)
-    {				/* check for top level plan */
+    {
+      /* check for top level plan */
       return;
     }
 
@@ -1414,12 +1417,12 @@ qo_plan_print_sort_spec (QO_PLAN * plan, FILE * f, int howfar)
  *   howfar(in):
  */
 static void
-qo_plan_print_costs (QO_PLAN * plan, FILE * f, int howfar)
+qo_plan_print_costs (QO_PLAN *plan, FILE *f, int howfar)
 {
   double fixed = plan->fixed_cpu_cost + plan->fixed_io_cost;
   double variable = plan->variable_cpu_cost + plan->variable_io_cost;
   double card = (plan->plan_type == QO_PLANTYPE_JOIN && QO_IS_NL_JOIN (plan) && plan->limit_nljoin_guessed_card > 0)
-    ? plan->limit_nljoin_guessed_card : (plan->info)->cardinality;
+		? plan->limit_nljoin_guessed_card : (plan->info)->cardinality;
 
   fprintf (f, "\n" INDENTED_TITLE_FMT "%.0f card %.0f", (int) howfar, ' ', "cost:", fixed + variable, card);
 
@@ -1439,22 +1442,22 @@ qo_plan_print_costs (QO_PLAN * plan, FILE * f, int howfar)
  *   howfar(in):
  */
 static void
-qo_plan_print_projected_segs (QO_PLAN * plan, FILE * f, int howfar)
+qo_plan_print_projected_segs (QO_PLAN *plan, FILE *f, int howfar)
 {
   int sx;
   const char *prefix = "";
   BITSET_ITERATOR si;
 
-  if (!((plan->info)->env->dump_enable))
+  if (! ((plan->info)->env->dump_enable))
     {
       return;
     }
 
   fprintf (f, "\n" INDENTED_TITLE_FMT, (int) howfar, ' ', "segs:");
-  for (sx = bitset_iterate (&((plan->info)->projected_segs), &si); sx != -1; sx = bitset_next_member (&si))
+  for (sx = bitset_iterate (& ((plan->info)->projected_segs), &si); sx != -1; sx = bitset_next_member (&si))
     {
       fputs (prefix, f);
-      qo_seg_fprint (&(plan->info)->env->segs[sx], f);
+      qo_seg_fprint (& (plan->info)->env->segs[sx], f);
       prefix = ", ";
     }
 }
@@ -1468,9 +1471,9 @@ qo_plan_print_projected_segs (QO_PLAN * plan, FILE * f, int howfar)
  *   howfar(in):
  */
 static void
-qo_plan_print_sarged_terms (QO_PLAN * plan, FILE * f, int howfar)
+qo_plan_print_sarged_terms (QO_PLAN *plan, FILE *f, int howfar)
 {
-  if (!bitset_is_empty (&(plan->sarged_terms)))
+  if (!bitset_is_empty (& (plan->sarged_terms)))
     {
       fprintf (f, "\n" INDENTED_TITLE_FMT, (int) howfar, ' ', "sargs:");
       qo_termset_fprint ((plan->info)->env, &plan->sarged_terms, f);
@@ -1485,17 +1488,17 @@ qo_plan_print_sarged_terms (QO_PLAN * plan, FILE * f, int howfar)
  *   howfar(in):
  */
 static void
-qo_plan_print_outer_join_terms (QO_PLAN * plan, FILE * f, int howfar)
+qo_plan_print_outer_join_terms (QO_PLAN *plan, FILE *f, int howfar)
 {
-  if (!bitset_is_empty (&(plan->plan_un.join.during_join_terms)))
+  if (!bitset_is_empty (& (plan->plan_un.join.during_join_terms)))
     {
       fprintf (f, "\n" INDENTED_TITLE_FMT, (int) howfar, ' ', "during:");
-      qo_termset_fprint ((plan->info)->env, &(plan->plan_un.join.during_join_terms), f);
+      qo_termset_fprint ((plan->info)->env, & (plan->plan_un.join.during_join_terms), f);
     }
-  if (!bitset_is_empty (&(plan->plan_un.join.after_join_terms)))
+  if (!bitset_is_empty (& (plan->plan_un.join.after_join_terms)))
     {
       fprintf (f, "\n" INDENTED_TITLE_FMT, (int) howfar, ' ', "after:");
-      qo_termset_fprint ((plan->info)->env, &(plan->plan_un.join.after_join_terms), f);
+      qo_termset_fprint ((plan->info)->env, & (plan->plan_un.join.after_join_terms), f);
     }
 }
 
@@ -1508,12 +1511,12 @@ qo_plan_print_outer_join_terms (QO_PLAN * plan, FILE * f, int howfar)
  *   howfar(in):
  */
 static void
-qo_plan_print_subqueries (QO_PLAN * plan, FILE * f, int howfar)
+qo_plan_print_subqueries (QO_PLAN *plan, FILE *f, int howfar)
 {
-  if (!bitset_is_empty (&(plan->subqueries)))
+  if (!bitset_is_empty (& (plan->subqueries)))
     {
       fprintf (f, "\n" INDENTED_TITLE_FMT, (int) howfar, ' ', "subqs: ");
-      bitset_print (&(plan->subqueries), f);
+      bitset_print (& (plan->subqueries), f);
     }
 }
 
@@ -1526,7 +1529,7 @@ qo_plan_print_subqueries (QO_PLAN * plan, FILE * f, int howfar)
  *   howfar(in):
  */
 static void
-qo_plan_print_analytic_eval (QO_PLAN * plan, FILE * f, int howfar)
+qo_plan_print_analytic_eval (QO_PLAN *plan, FILE *f, int howfar)
 {
   ANALYTIC_EVAL_TYPE *eval;
   ANALYTIC_TYPE *func;
@@ -1599,7 +1602,7 @@ qo_plan_print_analytic_eval (QO_PLAN * plan, FILE * f, int howfar)
  *   scan_method(in):
  */
 static QO_PLAN *
-qo_scan_new (QO_INFO * info, QO_NODE * node, QO_SCANMETHOD scan_method)
+qo_scan_new (QO_INFO *info, QO_NODE *node, QO_SCANMETHOD scan_method)
 {
   QO_PLAN *plan;
 
@@ -1621,12 +1624,12 @@ qo_scan_new (QO_INFO * info, QO_NODE * node, QO_SCANMETHOD scan_method)
   plan->plan_un.scan.scan_method = scan_method;
   plan->plan_un.scan.node = node;
 
-  bitset_assign (&(plan->sarged_terms), &(QO_NODE_SARGS (node)));
+  bitset_assign (& (plan->sarged_terms), & (QO_NODE_SARGS (node)));
 
-  bitset_assign (&(plan->subqueries), &(QO_NODE_SUBQUERIES (node)));
-  bitset_init (&(plan->plan_un.scan.terms), info->env);
-  bitset_init (&(plan->plan_un.scan.kf_terms), info->env);
-  bitset_init (&(plan->plan_un.scan.hash_terms), info->env);
+  bitset_assign (& (plan->subqueries), & (QO_NODE_SUBQUERIES (node)));
+  bitset_init (& (plan->plan_un.scan.terms), info->env);
+  bitset_init (& (plan->plan_un.scan.kf_terms), info->env);
+  bitset_init (& (plan->plan_un.scan.hash_terms), info->env);
   plan->plan_un.scan.index_equi = false;
   plan->plan_un.scan.index_cover = false;
   plan->plan_un.scan.index_iss = false;
@@ -1634,7 +1637,7 @@ qo_scan_new (QO_INFO * info, QO_NODE * node, QO_SCANMETHOD scan_method)
   plan->plan_un.scan.index = NULL;
 
   plan->multi_range_opt_use = PLAN_MULTI_RANGE_OPT_NO;
-  bitset_init (&(plan->plan_un.scan.multi_col_range_segs), info->env);
+  bitset_init (& (plan->plan_un.scan.multi_col_range_segs), info->env);
 
   return plan;
 }
@@ -1646,12 +1649,12 @@ qo_scan_new (QO_INFO * info, QO_NODE * node, QO_SCANMETHOD scan_method)
 *   plan(in):
  */
 static void
-qo_scan_free (QO_PLAN * plan)
+qo_scan_free (QO_PLAN *plan)
 {
-  bitset_delset (&(plan->plan_un.scan.terms));
-  bitset_delset (&(plan->plan_un.scan.kf_terms));
-  bitset_delset (&(plan->plan_un.scan.hash_terms));
-  bitset_delset (&(plan->plan_un.scan.multi_col_range_segs));
+  bitset_delset (& (plan->plan_un.scan.terms));
+  bitset_delset (& (plan->plan_un.scan.kf_terms));
+  bitset_delset (& (plan->plan_un.scan.hash_terms));
+  bitset_delset (& (plan->plan_un.scan.multi_col_range_segs));
 }
 
 
@@ -1662,7 +1665,7 @@ qo_scan_free (QO_PLAN * plan)
  *   node(in):
  */
 static QO_PLAN *
-qo_seq_scan_new (QO_INFO * info, QO_NODE * node)
+qo_seq_scan_new (QO_INFO *info, QO_NODE *node)
 {
   QO_PLAN *plan;
 
@@ -1674,8 +1677,8 @@ qo_seq_scan_new (QO_INFO * info, QO_NODE * node)
 
   plan->vtbl = &qo_seq_scan_plan_vtbl;
 
-  assert (bitset_is_empty (&(plan->plan_un.scan.terms)));
-  assert (bitset_is_empty (&(plan->plan_un.scan.kf_terms)));
+  assert (bitset_is_empty (& (plan->plan_un.scan.terms)));
+  assert (bitset_is_empty (& (plan->plan_un.scan.kf_terms)));
   assert (plan->plan_un.scan.index_equi == false);
   assert (plan->plan_un.scan.index_cover == false);
   assert (plan->plan_un.scan.index_iss == false);
@@ -1695,7 +1698,7 @@ qo_seq_scan_new (QO_INFO * info, QO_NODE * node)
  *   planp(in):
  */
 static void
-qo_sscan_cost (QO_PLAN * planp)
+qo_sscan_cost (QO_PLAN *planp)
 {
   QO_NODE *nodep;
   double extra_weight = 0.0;
@@ -1717,7 +1720,7 @@ qo_sscan_cost (QO_PLAN * planp)
       planp->variable_cpu_cost = (double) QO_NODE_NCARD (nodep) * (double) QO_CPU_WEIGHT;
     }
 
-  extra_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(QO_NODE_SARGS (nodep)));
+  extra_weight = qo_sum_bitset_term_cost_weights (planp->info->env, & (QO_NODE_SARGS (nodep)));
 
   planp->variable_cpu_cost += scan_rows * QO_CPU_WEIGHT * extra_weight * QO_SSCAN_FILTER_CPU_FACTOR;
   planp->variable_io_cost = (double) QO_NODE_TCARD (nodep);
@@ -1741,21 +1744,21 @@ qo_sscan_cost (QO_PLAN * planp)
 }
 
 static void
-qo_apply_scan_term_cpu_overhead (QO_PLAN * planp)
+qo_apply_scan_term_cpu_overhead (QO_PLAN *planp)
 {
   double scan_rows = MAX (1.0, planp->info->scan_rows);
   double range_weight = 0.0;
   double key_filter_weight = 0.0;
   double data_filter_weight = 0.0;
 
-  range_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(planp->plan_un.scan.terms));
+  range_weight = qo_sum_bitset_term_cost_weights (planp->info->env, & (planp->plan_un.scan.terms));
 
-  key_filter_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(planp->plan_un.scan.kf_terms));
+  key_filter_weight = qo_sum_bitset_term_cost_weights (planp->info->env, & (planp->plan_un.scan.kf_terms));
 
-  data_filter_weight = qo_sum_bitset_term_cost_weights (planp->info->env, &(planp->sarged_terms));
+  data_filter_weight = qo_sum_bitset_term_cost_weights (planp->info->env, & (planp->sarged_terms));
 
   planp->variable_cpu_cost +=
-    scan_rows * QO_CPU_WEIGHT * (1.2 * range_weight + 1.0 * key_filter_weight + 0.8 * data_filter_weight);
+	  scan_rows * QO_CPU_WEIGHT * (1.2 * range_weight + 1.0 * key_filter_weight + 0.8 * data_filter_weight);
 }
 
 /*
@@ -1765,7 +1768,7 @@ qo_apply_scan_term_cpu_overhead (QO_PLAN * planp)
  *    index_entyp(in):
  */
 static bool
-qo_index_has_bit_attr (QO_INDEX_ENTRY * index_entryp)
+qo_index_has_bit_attr (QO_INDEX_ENTRY *index_entryp)
 {
   TP_DOMAIN *domain;
   int col_num = index_entryp->col_num;
@@ -1794,8 +1797,8 @@ qo_index_has_bit_attr (QO_INDEX_ENTRY * index_entryp)
  *   indexable_terms(in):
  */
 static QO_PLAN *
-qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entry, QO_SCANMETHOD scan_method,
-		   BITSET * range_terms, BITSET * indexable_terms)
+qo_index_scan_new (QO_INFO *info, QO_NODE *node, QO_NODE_INDEX_ENTRY *ni_entry, QO_SCANMETHOD scan_method,
+		   BITSET *range_terms, BITSET *indexable_terms)
 {
   QO_PLAN *plan = NULL;
   BITSET_ITERATOR iter;
@@ -1815,7 +1818,7 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
   assert (scan_method == QO_SCANMETHOD_INDEX_SCAN || scan_method == QO_SCANMETHOD_INDEX_ORDERBY_SCAN
 	  || scan_method == QO_SCANMETHOD_INDEX_GROUPBY_SCAN || scan_method == QO_SCANMETHOD_INDEX_SCAN_INSPECT);
 
-  assert (scan_method != QO_SCANMETHOD_INDEX_SCAN || !(ni_entry->head->force < 0));
+  assert (scan_method != QO_SCANMETHOD_INDEX_SCAN || ! (ni_entry->head->force < 0));
   assert (scan_method == QO_SCANMETHOD_INDEX_SCAN_INSPECT || range_terms != NULL);
 
   plan = qo_scan_new (info, node, scan_method);
@@ -1831,7 +1834,7 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
   if (range_terms != NULL)
     {
       /* remove key-range terms from sarged terms */
-      bitset_difference (&(plan->sarged_terms), range_terms);
+      bitset_difference (& (plan->sarged_terms), range_terms);
     }
 
   /* remove key-range terms from remaining terms */
@@ -1840,7 +1843,7 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
       bitset_assign (&remaining_terms, indexable_terms);
       bitset_difference (&remaining_terms, range_terms);
     }
-  bitset_union (&remaining_terms, &(plan->sarged_terms));
+  bitset_union (&remaining_terms, & (plan->sarged_terms));
 
   /*
    * This is, in essence, the selectivity of the index.  We
@@ -1856,8 +1859,8 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
   if (range_terms != NULL)
     {
       /* set key-range terms */
-      bitset_assign (&(plan->plan_un.scan.terms), range_terms);
-      bitset_assign (&(plan->plan_un.scan.multi_col_range_segs), &(index_entryp->multi_col_range_segs));
+      bitset_assign (& (plan->plan_un.scan.terms), range_terms);
+      bitset_assign (& (plan->plan_un.scan.multi_col_range_segs), & (index_entryp->multi_col_range_segs));
       for (t = bitset_iterate (range_terms, &iter); t != -1; t = bitset_next_member (&iter))
 	{
 	  term = QO_ENV_TERM (env, t);
@@ -1874,7 +1877,7 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
 	}
     }
 
-  if (!bitset_is_empty (&(plan->plan_un.scan.terms)) && t == -1)
+  if (!bitset_is_empty (& (plan->plan_un.scan.terms)) && t == -1)
     {
       /* is all equi-cond key-range terms */
       plan->plan_un.scan.index_equi = true;
@@ -1887,7 +1890,7 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
   if (index_entryp->constraints->func_index_info && index_entryp->cover_segments == false)
     {
       /* do not permit key-filter */
-      assert (bitset_is_empty (&(plan->plan_un.scan.kf_terms)));
+      assert (bitset_is_empty (& (plan->plan_un.scan.kf_terms)));
     }
   else
     {
@@ -1910,13 +1913,13 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
 	      continue;
 	    }
 
-	  if (!bitset_is_empty (&(QO_TERM_SUBQUERIES (term))))
+	  if (!bitset_is_empty (& (QO_TERM_SUBQUERIES (term))))
 	    {
 	      continue;		/* term contains correlated subquery */
 	    }
 
 	  /* check for no key-range index scan */
-	  if (bitset_is_empty (&(plan->plan_un.scan.terms)))
+	  if (bitset_is_empty (& (plan->plan_un.scan.terms)))
 	    {
 	      if (qo_is_filter_index (index_entryp) || qo_is_iscan_from_orderby (plan)
 		  || qo_is_iscan_from_groupby (plan))
@@ -1934,8 +1937,8 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
 		}
 	    }
 
-	  bitset_assign (&term_segs, &(QO_TERM_SEGS (term)));
-	  bitset_intersect (&term_segs, &(QO_NODE_SEGS (node)));
+	  bitset_assign (&term_segs, & (QO_TERM_SEGS (term)));
+	  bitset_intersect (&term_segs, & (QO_NODE_SEGS (node)));
 
 	  /* if the term is consisted by only the node's segments which appear in scan terms, it will be key-filter.
 	   * otherwise will be data filter
@@ -1944,14 +1947,14 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
 	    {
 	      if (bitset_subset (&index_segs, &term_segs))
 		{
-		  bitset_add (&(plan->plan_un.scan.kf_terms), t);
+		  bitset_add (& (plan->plan_un.scan.kf_terms), t);
 		}
 	    }
 	}
 
       /* exclude key filter terms from sargs terms */
-      bitset_difference (&(plan->sarged_terms), &(plan->plan_un.scan.kf_terms));
-      bitset_difference (&remaining_terms, &(plan->plan_un.scan.kf_terms));
+      bitset_difference (& (plan->sarged_terms), & (plan->plan_un.scan.kf_terms));
+      bitset_difference (&remaining_terms, & (plan->plan_un.scan.kf_terms));
     }
 
   /* check for index cover scan */
@@ -1965,7 +1968,7 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
 	    {
 	      term = QO_ENV_TERM (env, t);
 
-	      if (!bitset_is_empty (&(QO_TERM_SUBQUERIES (term))))
+	      if (!bitset_is_empty (& (QO_TERM_SUBQUERIES (term))))
 		{
 		  /* term contains correlated subquery */
 		  continue;
@@ -1982,13 +1985,13 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
 	}
     }
 
-  assert (!bitset_intersects (&(plan->plan_un.scan.terms), &(plan->plan_un.scan.kf_terms)));
+  assert (!bitset_intersects (& (plan->plan_un.scan.terms), & (plan->plan_un.scan.kf_terms)));
 
-  assert (!bitset_intersects (&(plan->plan_un.scan.terms), &(plan->sarged_terms)));
-  assert (!bitset_intersects (&(plan->plan_un.scan.kf_terms), &(plan->sarged_terms)));
+  assert (!bitset_intersects (& (plan->plan_un.scan.terms), & (plan->sarged_terms)));
+  assert (!bitset_intersects (& (plan->plan_un.scan.kf_terms), & (plan->sarged_terms)));
 
-  assert (!bitset_intersects (&(plan->plan_un.scan.terms), &remaining_terms));
-  assert (!bitset_intersects (&(plan->plan_un.scan.kf_terms), &remaining_terms));
+  assert (!bitset_intersects (& (plan->plan_un.scan.terms), &remaining_terms));
+  assert (!bitset_intersects (& (plan->plan_un.scan.kf_terms), &remaining_terms));
 
   bitset_delset (&remaining_terms);
   bitset_delset (&term_segs);
@@ -1998,7 +2001,7 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
   plan->plan_un.scan.index_iss = false;	/* init */
   if (index_entryp->is_iss_candidate)
     {
-      assert (!bitset_is_empty (&(plan->plan_un.scan.terms)));
+      assert (!bitset_is_empty (& (plan->plan_un.scan.terms)));
       assert (index_entryp->ils_prefix_len == 0);
       assert (!qo_is_filter_index (index_entryp));
 
@@ -2028,8 +2031,8 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
 	  if (!qo_is_index_loose_scan (plan))
 	    {
 	      /* check for no key-range, no key-filter index scan */
-	      if (qo_is_iscan (plan) && bitset_is_empty (&(plan->plan_un.scan.terms))
-		  && bitset_is_empty (&(plan->plan_un.scan.kf_terms)))
+	      if (qo_is_iscan (plan) && bitset_is_empty (& (plan->plan_un.scan.terms))
+		  && bitset_is_empty (& (plan->plan_un.scan.kf_terms)))
 		{
 		  assert (!qo_is_iscan_from_groupby (plan));
 		  assert (!qo_is_iscan_from_orderby (plan));
@@ -2043,8 +2046,8 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
     }
 
   /* check for no key-range, no key-filter index scan */
-  if (qo_is_iscan (plan) && bitset_is_empty (&(plan->plan_un.scan.terms))
-      && bitset_is_empty (&(plan->plan_un.scan.kf_terms)) && scan_method != QO_SCANMETHOD_INDEX_SCAN_INSPECT)
+  if (qo_is_iscan (plan) && bitset_is_empty (& (plan->plan_un.scan.terms))
+      && bitset_is_empty (& (plan->plan_un.scan.kf_terms)) && scan_method != QO_SCANMETHOD_INDEX_SCAN_INSPECT)
     {
       assert (!qo_is_iscan_from_groupby (plan));
       assert (!qo_is_iscan_from_orderby (plan));
@@ -2053,7 +2056,7 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
       if (qo_is_filter_index (index_entryp) || qo_is_index_loose_scan (plan))
 	{
 	  /* filter index has a pre-defined key-range. */
-	  assert (bitset_is_empty (&(plan->plan_un.scan.terms)));
+	  assert (bitset_is_empty (& (plan->plan_un.scan.terms)));
 
 	  ;			/* go ahead */
 	}
@@ -2088,7 +2091,7 @@ qo_index_scan_new (QO_INFO * info, QO_NODE * node, QO_NODE_INDEX_ENTRY * ni_entr
  *   planp(in):
  */
 static void
-qo_iscan_cost (QO_PLAN * planp)
+qo_iscan_cost (QO_PLAN *planp)
 {
   QO_NODE *nodep;
   QO_NODE_INDEX_ENTRY *ni_entryp;
@@ -2103,7 +2106,7 @@ qo_iscan_cost (QO_PLAN * planp)
   nodep = planp->plan_un.scan.node;
   ni_entryp = planp->plan_un.scan.index;
   index_entryp = (ni_entryp)->head;
-  cum_statsp = &(ni_entryp)->cum_stats;
+  cum_statsp = & (ni_entryp)->cum_stats;
 
   if (index_entryp->force < 0)
     {
@@ -2146,12 +2149,12 @@ qo_iscan_cost (QO_PLAN * planp)
   pkeys_num = MIN (n, cum_statsp->pkeys_size);
   assert (pkeys_num <= BTREE_STATS_PKEYS_NUM);
 
-  if (bitset_is_empty (&(planp->plan_un.scan.terms)))
+  if (bitset_is_empty (& (planp->plan_un.scan.terms)))
     {
       assert (!qo_is_index_iss_scan (planp));
     }
 
-  for (i = 0, t = bitset_iterate (&(planp->plan_un.scan.terms), &iter); t != -1; t = bitset_next_member (&iter))
+  for (i = 0, t = bitset_iterate (& (planp->plan_un.scan.terms), &iter); t != -1; t = bitset_next_member (&iter))
     {
       termp = QO_ENV_TERM (QO_NODE_ENV (nodep), t);
       sel *= QO_TERM_SELECTIVITY (termp);
@@ -2186,7 +2189,8 @@ qo_iscan_cost (QO_PLAN * planp)
       sel_limit = 1.0 / (double) cum_statsp->pkeys[index];
     }
   else
-    {				/* can not use btree partial-key statistics */
+    {
+      /* can not use btree partial-key statistics */
       if (cum_statsp->keys >= 1)
 	{
 	  sel_limit = 1.0 / (double) cum_statsp->keys;
@@ -2194,7 +2198,8 @@ qo_iscan_cost (QO_PLAN * planp)
       else
 	{
 	  if (QO_NODE_NCARD (nodep) == 0)
-	    {			/* empty class */
+	    {
+	      /* empty class */
 	      sel_limit = sel = 0.0;
 	    }
 	  else if (QO_NODE_NCARD (nodep) >= 1)
@@ -2210,7 +2215,7 @@ qo_iscan_cost (QO_PLAN * planp)
 
   /* selectivity of the index key filter terms */
   filter_sel = 1.0;
-  for (t = bitset_iterate (&(planp->plan_un.scan.kf_terms), &iter); t != -1; t = bitset_next_member (&iter))
+  for (t = bitset_iterate (& (planp->plan_un.scan.kf_terms), &iter); t != -1; t = bitset_next_member (&iter))
     {
       termp = QO_ENV_TERM (QO_NODE_ENV (nodep), t);
       filter_sel *= QO_TERM_SELECTIVITY (termp);
@@ -2287,7 +2292,7 @@ qo_iscan_cost (QO_PLAN * planp)
 
 
 static void
-qo_scan_fprint (QO_PLAN * plan, FILE * f, int howfar)
+qo_scan_fprint (QO_PLAN *plan, FILE *f, int howfar)
 {
   bool natural_desc_index = false;
 
@@ -2343,7 +2348,7 @@ qo_scan_fprint (QO_PLAN * plan, FILE * f, int howfar)
       /* print index covering */
       if (qo_is_index_covering_scan (plan))
 	{
-	  if (bitset_cardinality (&(plan->plan_un.scan.terms)) > 0)
+	  if (bitset_cardinality (& (plan->plan_un.scan.terms)) > 0)
 	    {
 	      fprintf (f, " ");
 	    }
@@ -2376,10 +2381,10 @@ qo_scan_fprint (QO_PLAN * plan, FILE * f, int howfar)
 	  fprintf (f, " (desc_index forced)");
 	}
 
-      if (!bitset_is_empty (&(plan->plan_un.scan.kf_terms)))
+      if (!bitset_is_empty (& (plan->plan_un.scan.kf_terms)))
 	{
 	  fprintf (f, "\n" INDENTED_TITLE_FMT, (int) howfar, ' ', "filtr: ");
-	  qo_termset_fprint ((plan->info)->env, &(plan->plan_un.scan.kf_terms), f);
+	  qo_termset_fprint ((plan->info)->env, & (plan->plan_un.scan.kf_terms), f);
 	}
     }
 }
@@ -2392,7 +2397,7 @@ qo_scan_fprint (QO_PLAN * plan, FILE * f, int howfar)
  *   howfar(in):
  */
 static void
-qo_scan_info (QO_PLAN * plan, FILE * f, int howfar)
+qo_scan_info (QO_PLAN *plan, FILE *f, int howfar)
 {
   QO_NODE *node = plan->plan_un.scan.node;
   int i, n = 1;
@@ -2453,15 +2458,15 @@ qo_scan_info (QO_PLAN * plan, FILE * f, int howfar)
 	    }
 	}
 
-      for (i = bitset_iterate (&(plan->plan_un.scan.terms), &bi); i != -1; i = bitset_next_member (&bi))
+      for (i = bitset_iterate (& (plan->plan_un.scan.terms), &bi); i != -1; i = bitset_next_member (&bi))
 	{
 	  fprintf (f, "%s%s", separator, qo_term_string (QO_ENV_TERM (env, i), buf));
 	  separator = " and ";
 	}
-      if (bitset_cardinality (&(plan->plan_un.scan.kf_terms)) > 0)
+      if (bitset_cardinality (& (plan->plan_un.scan.kf_terms)) > 0)
 	{
 	  separator = ", [";
-	  for (i = bitset_iterate (&(plan->plan_un.scan.kf_terms), &bi); i != -1; i = bitset_next_member (&bi))
+	  for (i = bitset_iterate (& (plan->plan_un.scan.kf_terms), &bi); i != -1; i = bitset_next_member (&bi))
 	    {
 	      fprintf (f, "%s%s", separator, qo_term_string (QO_ENV_TERM (env, i), buf));
 	      separator = " and ";
@@ -2514,14 +2519,15 @@ qo_scan_info (QO_PLAN * plan, FILE * f, int howfar)
  *   sort_type(in):
  */
 static QO_PLAN *
-qo_sort_new (QO_PLAN * root, QO_EQCLASS * order, SORT_TYPE sort_type)
+qo_sort_new (QO_PLAN *root, QO_EQCLASS *order, SORT_TYPE sort_type)
 {
   QO_PLAN *subplan, *plan;
 
   subplan = root;
 
   if (sort_type == SORT_TEMP)
-    {				/* is not top-level plan */
+    {
+      /* is not top-level plan */
       /* skip out top-level sort plan */
       for (; subplan && subplan->plan_type == QO_PLANTYPE_SORT && subplan->plan_un.sort.sort_type != SORT_LIMIT;
 	   subplan = subplan->plan_un.sort.subplan)
@@ -2546,7 +2552,7 @@ qo_sort_new (QO_PLAN * root, QO_EQCLASS * order, SORT_TYPE sort_type)
       for (; subplan && subplan->plan_type == QO_PLANTYPE_SORT && subplan->plan_un.sort.sort_type != SORT_LIMIT;
 	   subplan = subplan->plan_un.sort.subplan)
 	{
-	  if (!bitset_is_empty (&(subplan->sarged_terms)))
+	  if (!bitset_is_empty (& (subplan->sarged_terms)))
 	    {
 	      break;
 	    }
@@ -2603,7 +2609,7 @@ qo_sort_new (QO_PLAN * root, QO_EQCLASS * order, SORT_TYPE sort_type)
  *   parent_data(in):
  */
 static void
-qo_sort_walk (QO_PLAN * plan, void (*child_fn) (QO_PLAN *, void *), void *child_data,
+qo_sort_walk (QO_PLAN *plan, void (*child_fn) (QO_PLAN *, void *), void *child_data,
 	      void (*parent_fn) (QO_PLAN *, void *), void *parent_data)
 {
   if (child_fn)
@@ -2617,13 +2623,13 @@ qo_sort_walk (QO_PLAN * plan, void (*child_fn) (QO_PLAN *, void *), void *child_
 }
 
 static void
-qo_sort_fprint (QO_PLAN * plan, FILE * f, int howfar)
+qo_sort_fprint (QO_PLAN *plan, FILE *f, int howfar)
 {
   switch (plan->plan_un.sort.sort_type)
     {
     case SORT_TEMP:
       fprintf (f, "\n" INDENTED_TITLE_FMT, (int) howfar, ' ', "order:");
-      qo_eqclass_fprint_wrt (plan->order, &(plan->info->nodes), f);
+      qo_eqclass_fprint_wrt (plan->order, & (plan->info->nodes), f);
       break;
 
     case SORT_LIMIT:
@@ -2657,7 +2663,7 @@ qo_sort_fprint (QO_PLAN * plan, FILE * f, int howfar)
  *   howfar(in):
  */
 static void
-qo_sort_info (QO_PLAN * plan, FILE * f, int howfar)
+qo_sort_info (QO_PLAN *plan, FILE *f, int howfar)
 {
 
   switch (plan->plan_un.sort.sort_type)
@@ -2672,7 +2678,7 @@ qo_sort_info (QO_PLAN * plan, FILE * f, int howfar)
 	   * figure out what's going on.
 	   */
 	  fprintf (f, "\n%*c%s(", (int) howfar, ' ', (plan->vtbl)->info_string);
-	  qo_eqclass_fprint_wrt (plan->order, &(plan->info->nodes), f);
+	  qo_eqclass_fprint_wrt (plan->order, & (plan->info->nodes), f);
 	  fprintf (f, ")");
 #endif
 	}
@@ -2709,7 +2715,7 @@ qo_sort_info (QO_PLAN * plan, FILE * f, int howfar)
  *   planp(in):
  */
 static void
-qo_sort_cost (QO_PLAN * planp)
+qo_sort_cost (QO_PLAN *planp)
 {
   QO_PLAN *subplanp;
 
@@ -2746,7 +2752,7 @@ qo_sort_cost (QO_PLAN * planp)
 	{
 	  double save_ncard = QO_NODE_NCARD (subplanp->plan_un.scan.node);
 	  QO_NODE_NCARD (subplanp->plan_un.scan.node) = (double) db_get_bigint (&QO_ENV_LIMIT_VALUE (planp->info->env));
-	  (*(subplanp->vtbl)->cost_fn) (subplanp);
+	  (* (subplanp->vtbl)->cost_fn) (subplanp);
 	  QO_NODE_NCARD (subplanp->plan_un.scan.node) = save_ncard;
 	}
 
@@ -2811,7 +2817,8 @@ qo_sort_cost (QO_PLAN * planp)
 		      tcard = (double) QO_NODE_TCARD (subplanp->plan_un.scan.node);
 		      tcard *= 0.1;
 		      if (pages >= tcard)
-			{	/* big size sort list */
+			{
+			  /* big size sort list */
 			  sort_io *= 0.1;
 			}
 		    }
@@ -2855,9 +2862,9 @@ qo_sort_cost (QO_PLAN * planp)
  *   pinned_subqueries(in):
  */
 static QO_PLAN *
-qo_join_new (QO_INFO * info, JOIN_TYPE join_type, QO_JOINMETHOD join_method, QO_PLAN * outer, QO_PLAN * inner,
-	     BITSET * join_terms, BITSET * duj_terms, BITSET * afj_terms, BITSET * sarged_terms,
-	     BITSET * pinned_subqueries, BITSET * hash_terms)
+qo_join_new (QO_INFO *info, JOIN_TYPE join_type, QO_JOINMETHOD join_method, QO_PLAN *outer, QO_PLAN *inner,
+	     BITSET *join_terms, BITSET *duj_terms, BITSET *afj_terms, BITSET *sarged_terms,
+	     BITSET *pinned_subqueries, BITSET *hash_terms)
 {
   QO_PLAN *plan = NULL;
   QO_NODE *node = NULL;
@@ -2950,8 +2957,8 @@ qo_join_new (QO_INFO * info, JOIN_TYPE join_type, QO_JOINMETHOD join_method, QO_
        * *unordered*.  Check for that condition here.
        */
       plan->order =
-	bitset_intersects (&(QO_EQCLASS_SEGS (outer->order)),
-			   &((plan->info)->projected_segs)) ? outer->order : QO_UNORDERED;
+	      bitset_intersects (& (QO_EQCLASS_SEGS (outer->order)),
+				 & ((plan->info)->projected_segs)) ? outer->order : QO_UNORDERED;
 
       /* The current implementation of merge joins always produces a list file These two checks are necessary because
        * of restrictions in the current XASL implementation of merge joins.
@@ -2980,7 +2987,7 @@ qo_join_new (QO_INFO * info, JOIN_TYPE join_type, QO_JOINMETHOD join_method, QO_
       return NULL;
     }
 
-  node = QO_ENV_NODE (info->env, bitset_first_member (&((inner->info)->nodes)));
+  node = QO_ENV_NODE (info->env, bitset_first_member (& ((inner->info)->nodes)));
 
   assert (node != NULL);
   if (node == NULL)
@@ -3004,42 +3011,42 @@ qo_join_new (QO_INFO * info, JOIN_TYPE join_type, QO_JOINMETHOD join_method, QO_
   plan->plan_un.join.outer = qo_plan_add_ref (outer);
   plan->plan_un.join.inner = qo_plan_add_ref (inner);
 
-  bitset_init (&(plan->plan_un.join.join_terms), info->env);
-  bitset_init (&(plan->plan_un.join.during_join_terms), info->env);
-  bitset_init (&(plan->plan_un.join.after_join_terms), info->env);
-  bitset_init (&(plan->plan_un.join.hash_terms), info->env);
+  bitset_init (& (plan->plan_un.join.join_terms), info->env);
+  bitset_init (& (plan->plan_un.join.during_join_terms), info->env);
+  bitset_init (& (plan->plan_un.join.after_join_terms), info->env);
+  bitset_init (& (plan->plan_un.join.hash_terms), info->env);
 
   /* set join terms */
-  bitset_assign (&(plan->plan_un.join.join_terms), join_terms);
+  bitset_assign (& (plan->plan_un.join.join_terms), join_terms);
   /* set hash terms */
-  bitset_assign (&(plan->plan_un.join.hash_terms), hash_terms);
+  bitset_assign (& (plan->plan_un.join.hash_terms), hash_terms);
   /* add to out terms */
-  bitset_union (&sarg_out_terms, &(plan->plan_un.join.join_terms));
+  bitset_union (&sarg_out_terms, & (plan->plan_un.join.join_terms));
 
   if (IS_OUTER_JOIN_TYPE (join_type))
     {
       /* set during join terms */
-      bitset_assign (&(plan->plan_un.join.during_join_terms), duj_terms);
-      bitset_difference (&(plan->plan_un.join.during_join_terms), &sarg_out_terms);
+      bitset_assign (& (plan->plan_un.join.during_join_terms), duj_terms);
+      bitset_difference (& (plan->plan_un.join.during_join_terms), &sarg_out_terms);
       /* add to out terms */
-      bitset_union (&sarg_out_terms, &(plan->plan_un.join.during_join_terms));
+      bitset_union (&sarg_out_terms, & (plan->plan_un.join.during_join_terms));
 
       /* set after join terms */
-      bitset_assign (&(plan->plan_un.join.after_join_terms), afj_terms);
-      bitset_difference (&(plan->plan_un.join.after_join_terms), &sarg_out_terms);
+      bitset_assign (& (plan->plan_un.join.after_join_terms), afj_terms);
+      bitset_difference (& (plan->plan_un.join.after_join_terms), &sarg_out_terms);
       /* add to out terms */
-      bitset_union (&sarg_out_terms, &(plan->plan_un.join.after_join_terms));
+      bitset_union (&sarg_out_terms, & (plan->plan_un.join.after_join_terms));
     }
 
   /* set plan's sarged terms */
-  bitset_assign (&(plan->sarged_terms), sarged_terms);
-  bitset_difference (&(plan->sarged_terms), &sarg_out_terms);
+  bitset_assign (& (plan->sarged_terms), sarged_terms);
+  bitset_difference (& (plan->sarged_terms), &sarg_out_terms);
 
   /* Make sure that the pinned subqueries and the sargs are placed on the same node: by now the pinned subqueries are
    * very likely pinned here precisely because they're used by these sargs. Separating them (so that they get evaluated
    * in some different order) will yield incorrect results.
    */
-  bitset_assign (&(plan->subqueries), pinned_subqueries);
+  bitset_assign (& (plan->subqueries), pinned_subqueries);
 
   plan->parallel_opt_use = qo_check_hjoin_for_parallel_opt (plan);
 
@@ -3104,11 +3111,11 @@ qo_join_new (QO_INFO * info, JOIN_TYPE join_type, QO_JOINMETHOD join_method, QO_
  *   plan(in):
  */
 static void
-qo_join_free (QO_PLAN * plan)
+qo_join_free (QO_PLAN *plan)
 {
-  bitset_delset (&(plan->plan_un.join.join_terms));
-  bitset_delset (&(plan->plan_un.join.during_join_terms));
-  bitset_delset (&(plan->plan_un.join.after_join_terms));
+  bitset_delset (& (plan->plan_un.join.join_terms));
+  bitset_delset (& (plan->plan_un.join.during_join_terms));
+  bitset_delset (& (plan->plan_un.join.after_join_terms));
 }
 
 /*
@@ -3121,7 +3128,7 @@ qo_join_free (QO_PLAN * plan)
  *   parent_data(in):
  */
 static void
-qo_join_walk (QO_PLAN * plan, void (*child_fn) (QO_PLAN *, void *), void *child_data,
+qo_join_walk (QO_PLAN *plan, void (*child_fn) (QO_PLAN *, void *), void *child_data,
 	      void (*parent_fn) (QO_PLAN *, void *), void *parent_data)
 {
   if (child_fn)
@@ -3143,12 +3150,12 @@ qo_join_walk (QO_PLAN * plan, void (*child_fn) (QO_PLAN *, void *), void *child_
  *   howfar(in):
  */
 static void
-qo_join_fprint (QO_PLAN * plan, FILE * f, int howfar)
+qo_join_fprint (QO_PLAN *plan, FILE *f, int howfar)
 {
   switch (plan->plan_un.join.join_type)
     {
     case JOIN_INNER:
-      if (!bitset_is_empty (&(plan->plan_un.join.join_terms)))
+      if (!bitset_is_empty (& (plan->plan_un.join.join_terms)))
 	{
 	  fputs (" (inner join)", f);
 	}
@@ -3181,10 +3188,10 @@ qo_join_fprint (QO_PLAN * plan, FILE * f, int howfar)
       fputs (" (unknown join type)", f);
       break;
     }
-  if (!bitset_is_empty (&(plan->plan_un.join.join_terms)))
+  if (!bitset_is_empty (& (plan->plan_un.join.join_terms)))
     {
       fprintf (f, "\n" INDENTED_TITLE_FMT, (int) howfar, ' ', "edge:");
-      qo_termset_fprint ((plan->info)->env, &(plan->plan_un.join.join_terms), f);
+      qo_termset_fprint ((plan->info)->env, & (plan->plan_un.join.join_terms), f);
     }
   qo_plan_fprint (plan->plan_un.join.outer, f, howfar, "outer: ");
   qo_plan_fprint (plan->plan_un.join.inner, f, howfar, "inner: ");
@@ -3199,9 +3206,9 @@ qo_join_fprint (QO_PLAN * plan, FILE * f, int howfar)
  *   howfar(in):
  */
 static void
-qo_join_info (QO_PLAN * plan, FILE * f, int howfar)
+qo_join_info (QO_PLAN *plan, FILE *f, int howfar)
 {
-  if (!bitset_is_empty (&(plan->plan_un.join.join_terms)))
+  if (!bitset_is_empty (& (plan->plan_un.join.join_terms)))
     {
       QO_ENV *env;
       const char *separator;
@@ -3213,7 +3220,7 @@ qo_join_info (QO_PLAN * plan, FILE * f, int howfar)
       separator = "";
 
       fprintf (f, "\n%*c%s(", (int) howfar, ' ', (plan->vtbl)->info_string);
-      for (i = bitset_iterate (&(plan->plan_un.join.join_terms), &bi); i != -1; i = bitset_next_member (&bi))
+      for (i = bitset_iterate (& (plan->plan_un.join.join_terms), &bi); i != -1; i = bitset_next_member (&bi))
 	{
 	  fprintf (f, "%s%s", separator, qo_term_string (QO_ENV_TERM (env, i), buf));
 	  separator = " and ";
@@ -3253,7 +3260,7 @@ qo_join_info (QO_PLAN * plan, FILE * f, int howfar)
  * 6. Window / Recursive CTE / Hierarchical Query (CONNECT BY)
  */
 static bool
-qo_can_apply_limit_card (QO_ENV * env)
+qo_can_apply_limit_card (QO_ENV *env)
 {
   PARSER_CONTEXT *parser;
   PT_NODE *tree;
@@ -3321,7 +3328,7 @@ qo_can_apply_limit_card (QO_ENV * env)
 }
 
 static double
-qo_get_join_term_cost_weight (QO_TERM * term)
+qo_get_join_term_cost_weight (QO_TERM *term)
 {
   PT_NODE *expr;
 
@@ -3340,15 +3347,15 @@ qo_get_join_term_cost_weight (QO_TERM * term)
     {
     case PT_EQ:
     case PT_NULLSAFE_EQ:
-      {
-	PT_NODE *lhs = expr->info.expr.arg1;
+    {
+      PT_NODE *lhs = expr->info.expr.arg1;
 
-	if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
-	  {
-	    return QO_COST_WEIGHT_JOIN_STRING_EQUAL;
-	  }
-	return QO_COST_WEIGHT_JOIN_DEFAULT;
-      }
+      if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	{
+	  return QO_COST_WEIGHT_JOIN_STRING_EQUAL;
+	}
+      return QO_COST_WEIGHT_JOIN_DEFAULT;
+    }
 
     case PT_LT:
     case PT_LE:
@@ -3356,15 +3363,15 @@ qo_get_join_term_cost_weight (QO_TERM * term)
     case PT_GE:
     case PT_BETWEEN:
     case PT_RANGE:
-      {
-	PT_NODE *lhs = expr->info.expr.arg1;
+    {
+      PT_NODE *lhs = expr->info.expr.arg1;
 
-	if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
-	  {
-	    return QO_COST_WEIGHT_JOIN_STRING_RANGE;
-	  }
-	return QO_COST_WEIGHT_JOIN_DEFAULT;
-      }
+      if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	{
+	  return QO_COST_WEIGHT_JOIN_STRING_RANGE;
+	}
+      return QO_COST_WEIGHT_JOIN_DEFAULT;
+    }
 
     default:
       return QO_COST_WEIGHT_JOIN_DEFAULT;
@@ -3372,7 +3379,7 @@ qo_get_join_term_cost_weight (QO_TERM * term)
 }
 
 static double
-qo_sum_join_term_cost_weights (QO_ENV * env, BITSET * terms)
+qo_sum_join_term_cost_weights (QO_ENV *env, BITSET *terms)
 {
   BITSET_ITERATOR iter;
   int t;
@@ -3393,7 +3400,7 @@ qo_sum_join_term_cost_weights (QO_ENV * env, BITSET * terms)
 }
 
 static double
-qo_get_nljoin_term_cpu_overhead (QO_PLAN * planp, double guessed_result_cardinality)
+qo_get_nljoin_term_cpu_overhead (QO_PLAN *planp, double guessed_result_cardinality)
 {
   double join_term_weight_sum = 0.0;
 
@@ -3413,14 +3420,14 @@ qo_get_nljoin_term_cpu_overhead (QO_PLAN * planp, double guessed_result_cardinal
    * That is fine; the summed overhead will become 0.
    */
 
-  if (BITSET_IS_VALID (&(planp->plan_un.join.join_terms)))
+  if (BITSET_IS_VALID (& (planp->plan_un.join.join_terms)))
     {
-      join_term_weight_sum += qo_sum_join_term_cost_weights (planp->info->env, &(planp->plan_un.join.join_terms));
+      join_term_weight_sum += qo_sum_join_term_cost_weights (planp->info->env, & (planp->plan_un.join.join_terms));
     }
-  if (BITSET_IS_VALID (&(planp->plan_un.join.during_join_terms)))
+  if (BITSET_IS_VALID (& (planp->plan_un.join.during_join_terms)))
     {
       join_term_weight_sum +=
-	qo_sum_join_term_cost_weights (planp->info->env, &(planp->plan_un.join.during_join_terms));
+	      qo_sum_join_term_cost_weights (planp->info->env, & (planp->plan_un.join.during_join_terms));
     }
 
   if (join_term_weight_sum <= 0.0)
@@ -3432,8 +3439,8 @@ qo_get_nljoin_term_cpu_overhead (QO_PLAN * planp, double guessed_result_cardinal
 }
 
 static void
-qo_accumulate_memoize_outer_distinct_keys (QO_PLAN * planp, BITSET * terms, double guessed_outer_cardinality,
-					   double *best_ndvp)
+qo_accumulate_memoize_outer_distinct_keys (QO_PLAN *planp, BITSET *terms, double guessed_outer_cardinality,
+    double *best_ndvp)
 {
   QO_PLAN *inner;
   BITSET_ITERATOR iter;
@@ -3507,7 +3514,7 @@ qo_accumulate_memoize_outer_distinct_keys (QO_PLAN * planp, BITSET * terms, doub
 }
 
 static double
-qo_estimate_memoize_outer_distinct_keys (QO_PLAN * planp, double guessed_outer_cardinality)
+qo_estimate_memoize_outer_distinct_keys (QO_PLAN *planp, double guessed_outer_cardinality)
 {
   double best_ndv = 0.0;
 
@@ -3516,16 +3523,16 @@ qo_estimate_memoize_outer_distinct_keys (QO_PLAN * planp, double guessed_outer_c
       return guessed_outer_cardinality;
     }
 
-  qo_accumulate_memoize_outer_distinct_keys (planp, &(planp->plan_un.join.join_terms), guessed_outer_cardinality,
-					     &best_ndv);
-  qo_accumulate_memoize_outer_distinct_keys (planp, &(planp->plan_un.join.during_join_terms),
-					     guessed_outer_cardinality, &best_ndv);
+  qo_accumulate_memoize_outer_distinct_keys (planp, & (planp->plan_un.join.join_terms), guessed_outer_cardinality,
+      &best_ndv);
+  qo_accumulate_memoize_outer_distinct_keys (planp, & (planp->plan_un.join.during_join_terms),
+      guessed_outer_cardinality, &best_ndv);
 
   return (best_ndv > 0.0) ? MAX (1.0, best_ndv) : guessed_outer_cardinality;
 }
 
 static bool
-qo_is_memoize_favorable_plan (QO_PLAN * planp, double guessed_outer_cardinality, double *effective_outer_cardinality)
+qo_is_memoize_favorable_plan (QO_PLAN *planp, double guessed_outer_cardinality, double *effective_outer_cardinality)
 {
   QO_PLAN *inner;
   QO_INDEX_ENTRY *index_entryp;
@@ -3553,10 +3560,10 @@ qo_is_memoize_favorable_plan (QO_PLAN * planp, double guessed_outer_cardinality,
 
   index_entryp = inner->plan_un.scan.index->head;
   unique_lookup =
-    qo_is_all_unique_index_columns_are_equi_terms (inner)
-    || (index_entryp->constraints != NULL && SM_IS_CONSTRAINT_UNIQUE_FAMILY (index_entryp->constraints->type)
-	&& (BITSET_IS_VALID (&(planp->plan_un.join.join_terms))
-	    || BITSET_IS_VALID (&(planp->plan_un.join.during_join_terms))));
+	  qo_is_all_unique_index_columns_are_equi_terms (inner)
+	  || (index_entryp->constraints != NULL && SM_IS_CONSTRAINT_UNIQUE_FAMILY (index_entryp->constraints->type)
+	      && (BITSET_IS_VALID (& (planp->plan_un.join.join_terms))
+		  || BITSET_IS_VALID (& (planp->plan_un.join.during_join_terms))));
 
   if (!unique_lookup)
     {
@@ -3574,14 +3581,14 @@ qo_is_memoize_favorable_plan (QO_PLAN * planp, double guessed_outer_cardinality,
       outer_distinct_keys = qo_estimate_memoize_outer_distinct_keys (planp, guessed_outer_cardinality);
       miss_cardinality = MIN (guessed_outer_cardinality, outer_distinct_keys);
       *effective_outer_cardinality =
-	miss_cardinality + (guessed_outer_cardinality - miss_cardinality) * QO_NLJOIN_MEMOIZE_HIT_COST_RATIO;
+	      miss_cardinality + (guessed_outer_cardinality - miss_cardinality) * QO_NLJOIN_MEMOIZE_HIT_COST_RATIO;
     }
 
   return true;
 }
 
 static void
-qo_get_non_unique_residual_lookup_costs (QO_PLAN * planp, double outer_cardinality, double *cpu_costp, double *io_costp)
+qo_get_non_unique_residual_lookup_costs (QO_PLAN *planp, double outer_cardinality, double *cpu_costp, double *io_costp)
 {
   QO_PLAN *inner;
   QO_INDEX_ENTRY *index_entryp;
@@ -3607,7 +3614,7 @@ qo_get_non_unique_residual_lookup_costs (QO_PLAN * planp, double outer_cardinali
 
   inner = planp->plan_un.join.inner;
   if (inner == NULL || inner->info == NULL || !qo_is_iscan (inner) || inner->plan_un.scan.index == NULL
-      || inner->plan_un.scan.index->head == NULL || bitset_is_empty (&(inner->sarged_terms)))
+      || inner->plan_un.scan.index->head == NULL || bitset_is_empty (& (inner->sarged_terms)))
     {
       return;
     }
@@ -3618,7 +3625,7 @@ qo_get_non_unique_residual_lookup_costs (QO_PLAN * planp, double outer_cardinali
       return;
     }
 
-  cum_statsp = &(inner->plan_un.scan.index->cum_stats);
+  cum_statsp = & (inner->plan_un.scan.index->cum_stats);
   pkeys_num = MIN (index_entryp->col_num, cum_statsp->pkeys_size);
   if (pkeys_num <= 0 || cum_statsp->pkeys == NULL || cum_statsp->pkeys[0] <= 0)
     {
@@ -3631,7 +3638,7 @@ qo_get_non_unique_residual_lookup_costs (QO_PLAN * planp, double outer_cardinali
       return;
     }
 
-  residual_weight = qo_sum_bitset_term_cost_weights (inner->info->env, &(inner->sarged_terms));
+  residual_weight = qo_sum_bitset_term_cost_weights (inner->info->env, & (inner->sarged_terms));
   if (cpu_costp != NULL && residual_weight > 0.0)
     {
       /*
@@ -3640,7 +3647,7 @@ qo_get_non_unique_residual_lookup_costs (QO_PLAN * planp, double outer_cardinali
        * evaluation per candidate row.
        */
       *cpu_costp =
-	outer_cardinality * rows_per_lookup * (QO_COST_WEIGHT_PRED_DEFAULT + residual_weight) * QO_CPU_WEIGHT;
+	      outer_cardinality * rows_per_lookup * (QO_COST_WEIGHT_PRED_DEFAULT + residual_weight) * QO_CPU_WEIGHT;
     }
 
   if (io_costp != NULL && !qo_is_index_covering_scan (inner))
@@ -3656,7 +3663,7 @@ qo_get_non_unique_residual_lookup_costs (QO_PLAN * planp, double outer_cardinali
  *   planp(in):
  */
 static void
-qo_nljoin_cost (QO_PLAN * planp)
+qo_nljoin_cost (QO_PLAN *planp)
 {
   QO_PLAN *inner, *outer;
   double inner_io_cost, inner_cpu_cost, outer_io_cost, outer_cpu_cost;
@@ -3698,7 +3705,7 @@ qo_nljoin_cost (QO_PLAN * planp)
 	   && (planp->info->planner->can_apply_limit_card || qo_plan_is_orderby_skip_candidate (planp)))
     {
       limit_val = QO_PLAN_HAS_CONSTANT_LIMIT (planp)
-	? (double) db_get_bigint (&QO_ENV_LIMIT_VALUE (planp->info->env)) : GUESSED_BIND_LIMIT_CARD;
+		  ? (double) db_get_bigint (&QO_ENV_LIMIT_VALUE (planp->info->env)) : GUESSED_BIND_LIMIT_CARD;
 
       if (outer->plan_type == QO_PLANTYPE_SCAN)
 	{
@@ -3711,7 +3718,7 @@ qo_nljoin_cost (QO_PLAN * planp)
 	  outer_card = ((outer->info)->cardinality == 0) ? 1 : (outer->info)->cardinality;
 	  /* result = outer_guessed * (inner_card * selectivity) = outer_guessed * (plan_card/outer_card). */
 	  planp->limit_nljoin_guessed_card =
-	    MAX (1.0, guessed_result_cardinality * ((planp->info)->cardinality / outer_card));
+		  MAX (1.0, guessed_result_cardinality * ((planp->info)->cardinality / outer_card));
 	}
       else
 	{
@@ -3728,7 +3735,7 @@ qo_nljoin_cost (QO_PLAN * planp)
   inner_cost_cardinality = guessed_result_cardinality;
   (void) qo_is_memoize_favorable_plan (planp, guessed_result_cardinality, &inner_cost_cardinality);
   qo_get_non_unique_residual_lookup_costs (planp, inner_cost_cardinality, &non_unique_residual_lookup_cpu_cost,
-					   &non_unique_residual_lookup_io_cost);
+      &non_unique_residual_lookup_io_cost);
 
   inner_cpu_cost = inner_cost_cardinality * inner->variable_cpu_cost + non_unique_residual_lookup_cpu_cost;
 
@@ -3777,7 +3784,7 @@ qo_nljoin_cost (QO_PLAN * planp)
     env = inner->info ? (inner->info)->env : NULL;
     subq_cpu_cost = subq_io_cost = 0.0;	/* init */
 
-    for (i = bitset_iterate (&(inner->subqueries), &iter); i != -1; i = bitset_next_member (&iter))
+    for (i = bitset_iterate (& (inner->subqueries), &iter); i != -1; i = bitset_next_member (&iter))
       {
 	subq = env ? &env->subqueries[i] : NULL;
 	query = subq ? subq->node : NULL;
@@ -3790,7 +3797,7 @@ qo_nljoin_cost (QO_PLAN * planp)
     planp->variable_cpu_cost += guessed_result_cardinality * ISCAN_IO_HIT_RATIO * subq_cpu_cost;
     planp->variable_io_cost += guessed_result_cardinality * ISCAN_IO_HIT_RATIO * subq_io_cost;	/* assume IO as # blocks */
 
-    if (planp->info->env && BITSET_IS_VALID (&(planp->plan_un.join.join_terms)))
+    if (planp->info->env && BITSET_IS_VALID (& (planp->plan_un.join.join_terms)))
       {
 	planp->variable_cpu_cost += qo_get_nljoin_term_cpu_overhead (planp, guessed_result_cardinality);
       }
@@ -3820,7 +3827,7 @@ qo_nljoin_cost (QO_PLAN * planp)
  *   planp(in):
  */
 static void
-qo_mjoin_cost (QO_PLAN * planp)
+qo_mjoin_cost (QO_PLAN *planp)
 {
   QO_PLAN *inner;
   QO_PLAN *outer;
@@ -3899,7 +3906,7 @@ qo_mjoin_cost (QO_PLAN * planp)
  *   planp(in):
  */
 static void
-qo_hjoin_cost (QO_PLAN * plan_p)
+qo_hjoin_cost (QO_PLAN *plan_p)
 {
   QO_PLAN *inner_plan_p, *outer_plan_p;
   double inner_cardinality, outer_cardinality;
@@ -4029,7 +4036,7 @@ qo_hjoin_cost (QO_PLAN * plan_p)
  *   howfar(in):
  */
 static void
-qo_hjoin_fprint (QO_PLAN * plan, FILE * f, int howfar)
+qo_hjoin_fprint (QO_PLAN *plan, FILE *f, int howfar)
 {
   switch (plan->plan_un.join.join_type)
     {
@@ -4065,10 +4072,10 @@ qo_hjoin_fprint (QO_PLAN * plan, FILE * f, int howfar)
       break;
     }
 
-  if (!bitset_is_empty (&(plan->plan_un.join.join_terms)))
+  if (!bitset_is_empty (& (plan->plan_un.join.join_terms)))
     {
       fprintf (f, "\n" INDENTED_TITLE_FMT, (int) howfar, ' ', "edge:");
-      qo_termset_fprint ((plan->info)->env, &(plan->plan_un.join.join_terms), f);
+      qo_termset_fprint ((plan->info)->env, & (plan->plan_un.join.join_terms), f);
     }
 
   qo_plan_fprint (plan->plan_un.join.outer, f, howfar, "outer: ");
@@ -4086,8 +4093,8 @@ qo_hjoin_fprint (QO_PLAN * plan, FILE * f, int howfar)
  *   pinned_subqueries(in):
  */
 static QO_PLAN *
-qo_follow_new (QO_INFO * info, QO_PLAN * head_plan, QO_TERM * path_term, BITSET * sarged_terms,
-	       BITSET * pinned_subqueries)
+qo_follow_new (QO_INFO *info, QO_PLAN *head_plan, QO_TERM *path_term, BITSET *sarged_terms,
+	       BITSET *pinned_subqueries)
 {
   QO_PLAN *plan;
 
@@ -4114,13 +4121,13 @@ qo_follow_new (QO_INFO * info, QO_PLAN * head_plan, QO_TERM * path_term, BITSET 
 
   plan->multi_range_opt_use = PLAN_MULTI_RANGE_OPT_NO;
 
-  bitset_assign (&(plan->sarged_terms), sarged_terms);
-  bitset_remove (&(plan->sarged_terms), QO_TERM_IDX (path_term));
+  bitset_assign (& (plan->sarged_terms), sarged_terms);
+  bitset_remove (& (plan->sarged_terms), QO_TERM_IDX (path_term));
 
-  bitset_assign (&(plan->subqueries), pinned_subqueries);
+  bitset_assign (& (plan->subqueries), pinned_subqueries);
 
-  bitset_union (&(plan->sarged_terms), &(QO_NODE_SARGS (QO_TERM_TAIL (path_term))));
-  bitset_union (&(plan->subqueries), &(QO_NODE_SUBQUERIES (QO_TERM_TAIL (path_term))));
+  bitset_union (& (plan->sarged_terms), & (QO_NODE_SARGS (QO_TERM_TAIL (path_term))));
+  bitset_union (& (plan->subqueries), & (QO_NODE_SUBQUERIES (QO_TERM_TAIL (path_term))));
 
   qo_plan_compute_cost (plan);
 
@@ -4139,7 +4146,7 @@ qo_follow_new (QO_INFO * info, QO_PLAN * head_plan, QO_TERM * path_term, BITSET 
  *   parent_data(in):
  */
 static void
-qo_follow_walk (QO_PLAN * plan, void (*child_fn) (QO_PLAN *, void *), void *child_data,
+qo_follow_walk (QO_PLAN *plan, void (*child_fn) (QO_PLAN *, void *), void *child_data,
 		void (*parent_fn) (QO_PLAN *, void *), void *parent_data)
 {
   if (child_fn)
@@ -4160,7 +4167,7 @@ qo_follow_walk (QO_PLAN * plan, void (*child_fn) (QO_PLAN *, void *), void *chil
  *   howfar(in):
  */
 static void
-qo_follow_fprint (QO_PLAN * plan, FILE * f, int howfar)
+qo_follow_fprint (QO_PLAN *plan, FILE *f, int howfar)
 {
   fprintf (f, "\n" INDENTED_TITLE_FMT, (int) howfar, ' ', "edge:");
   qo_term_fprint (plan->plan_un.follow.path, f);
@@ -4175,7 +4182,7 @@ qo_follow_fprint (QO_PLAN * plan, FILE * f, int howfar)
  *   howfar(in):
  */
 static void
-qo_follow_info (QO_PLAN * plan, FILE * f, int howfar)
+qo_follow_info (QO_PLAN *plan, FILE *f, int howfar)
 {
   char buf[257] = { '\0', };
   fprintf (f, "\n%*c%s(%s)", (int) howfar, ' ', (plan->vtbl)->info_string,
@@ -4189,7 +4196,7 @@ qo_follow_info (QO_PLAN * plan, FILE * f, int howfar)
  *   planp(in):
  */
 static void
-qo_follow_cost (QO_PLAN * planp)
+qo_follow_cost (QO_PLAN *planp)
 {
   QO_PLAN *head;
   QO_NODE *tail;
@@ -4261,17 +4268,17 @@ qo_follow_cost (QO_PLAN * planp)
  *   pinned_subqueries(in):
  */
 static QO_PLAN *
-qo_cp_new (QO_INFO * info, QO_PLAN * outer, QO_PLAN * inner, BITSET * sarged_terms, BITSET * pinned_subqueries)
+qo_cp_new (QO_INFO *info, QO_PLAN *outer, QO_PLAN *inner, BITSET *sarged_terms, BITSET *pinned_subqueries)
 {
   QO_PLAN *plan;
   BITSET empty_terms;
 
   bitset_init (&empty_terms, info->env);
 
-  plan = qo_join_new (info, JOIN_INNER /* default */ ,
-		      QO_JOINMETHOD_NL_JOIN, outer, inner, &empty_terms /* join_terms */ ,
-		      &empty_terms /* duj_terms */ ,
-		      &empty_terms /* afj_terms */ ,
+  plan = qo_join_new (info, JOIN_INNER /* default */,
+		      QO_JOINMETHOD_NL_JOIN, outer, inner, &empty_terms /* join_terms */,
+		      &empty_terms /* duj_terms */,
+		      &empty_terms /* afj_terms */,
 		      sarged_terms, pinned_subqueries, &empty_terms /* hash_terms */ );
 
   bitset_delset (&empty_terms);
@@ -4286,7 +4293,7 @@ qo_cp_new (QO_INFO * info, QO_PLAN * outer, QO_PLAN * inner, BITSET * sarged_ter
  *   env(in):
  */
 static QO_PLAN *
-qo_worst_new (QO_ENV * env)
+qo_worst_new (QO_ENV *env)
 {
   QO_PLAN *plan;
 
@@ -4321,7 +4328,7 @@ qo_worst_new (QO_ENV * env)
  *   howfar(in):
  */
 static void
-qo_worst_fprint (QO_PLAN * plan, FILE * f, int howfar)
+qo_worst_fprint (QO_PLAN *plan, FILE *f, int howfar)
 {
 }
 
@@ -4333,7 +4340,7 @@ qo_worst_fprint (QO_PLAN * plan, FILE * f, int howfar)
  *   howfar(in):
  */
 static void
-qo_worst_info (QO_PLAN * plan, FILE * f, int howfar)
+qo_worst_info (QO_PLAN *plan, FILE *f, int howfar)
 {
   fprintf (f, "\n%*c%s", (int) howfar, ' ', (plan->vtbl)->info_string);
 }
@@ -4344,7 +4351,7 @@ qo_worst_info (QO_PLAN * plan, FILE * f, int howfar)
  *   planp(in):
  */
 static void
-qo_worst_cost (QO_PLAN * planp)
+qo_worst_cost (QO_PLAN *planp)
 {
   planp->fixed_cpu_cost = QO_INFINITY;
   planp->fixed_io_cost = QO_INFINITY;
@@ -4360,7 +4367,7 @@ qo_worst_cost (QO_PLAN * planp)
  *   planp(in):
  */
 static void
-qo_zero_cost (QO_PLAN * planp)
+qo_zero_cost (QO_PLAN *planp)
 {
   planp->fixed_cpu_cost = 0.0;
   planp->fixed_io_cost = 0.0;
@@ -4375,7 +4382,7 @@ qo_zero_cost (QO_PLAN * planp)
  *   order(in):
  */
 static QO_PLAN *
-qo_plan_order_by (QO_PLAN * plan, QO_EQCLASS * order)
+qo_plan_order_by (QO_PLAN *plan, QO_EQCLASS *order)
 {
   if (plan == NULL || order == QO_UNORDERED || plan->order == order)
     {
@@ -4398,7 +4405,7 @@ qo_plan_order_by (QO_PLAN * plan, QO_EQCLASS * order)
  *   sort_plan_p(in):
  */
 static QO_PLAN_COMPARE_RESULT
-qo_plan_cmp_prefer_covering_index (QO_PLAN * scan_plan_p, QO_PLAN * sort_plan_p)
+qo_plan_cmp_prefer_covering_index (QO_PLAN *scan_plan_p, QO_PLAN *sort_plan_p)
 {
   QO_PLAN *sort_subplan_p;
 
@@ -4434,7 +4441,7 @@ qo_plan_cmp_prefer_covering_index (QO_PLAN * scan_plan_p, QO_PLAN * sort_plan_p)
 	}
       else
 	{
-	  if (!bitset_is_empty (&(sort_subplan_p->plan_un.scan.terms)))
+	  if (!bitset_is_empty (& (sort_subplan_p->plan_un.scan.terms)))
 	    {
 	      /* prefer covering index scan with key-range */
 	      return PLAN_COMP_GT;
@@ -4452,7 +4459,7 @@ qo_plan_cmp_prefer_covering_index (QO_PLAN * scan_plan_p, QO_PLAN * sort_plan_p)
  *   b(in):
  */
 static QO_PLAN_COMPARE_RESULT
-qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
+qo_plan_cmp (QO_PLAN *a, QO_PLAN *b)
 {
 #if 1				/* TODO - do not delete me */
 #define QO_PLAN_CMP_CHECK_COST(a, b)
@@ -4766,7 +4773,8 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
     }
 
   if (a->plan_type != QO_PLANTYPE_SCAN || b->plan_type != QO_PLANTYPE_SCAN)
-    {				/* impossible case */
+    {
+      /* impossible case */
       goto cost_cmp;		/* give up */
     }
 
@@ -4883,7 +4891,7 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
     /* index entry of spec 'a' */
     a_ni = a->plan_un.scan.index;
     a_ent = (a_ni)->head;
-    a_cum = &(a_ni)->cum_stats;
+    a_cum = & (a_ni)->cum_stats;
 
     assert (a_cum->pkeys_size <= BTREE_STATS_PKEYS_NUM);
     for (i = 0; i < a_cum->pkeys_size; i++)
@@ -4896,19 +4904,19 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
     a_last = i;
 
     /* index range terms */
-    a_range = bitset_cardinality (&(a->plan_un.scan.terms));
-    if (a_range > 0 && !(a->plan_un.scan.index_equi))
+    a_range = bitset_cardinality (& (a->plan_un.scan.terms));
+    if (a_range > 0 && ! (a->plan_un.scan.index_equi))
       {
 	a_range--;		/* set the last equal range term */
       }
 
     /* index filter terms */
-    a_filter = bitset_cardinality (&(a->plan_un.scan.kf_terms));
+    a_filter = bitset_cardinality (& (a->plan_un.scan.kf_terms));
 
     /* index entry of spec 'b' */
     b_ni = b->plan_un.scan.index;
     b_ent = (b_ni)->head;
-    b_cum = &(b_ni)->cum_stats;
+    b_cum = & (b_ni)->cum_stats;
 
     assert (b_cum->pkeys_size <= BTREE_STATS_PKEYS_NUM);
     for (i = 0; i < b_cum->pkeys_size; i++)
@@ -4921,14 +4929,14 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
     b_last = i;
 
     /* index range terms */
-    b_range = bitset_cardinality (&(b->plan_un.scan.terms));
-    if (b_range > 0 && !(b->plan_un.scan.index_equi))
+    b_range = bitset_cardinality (& (b->plan_un.scan.terms));
+    if (b_range > 0 && ! (b->plan_un.scan.index_equi))
       {
 	b_range--;		/* set the last equal range term */
       }
 
     /* index filter terms */
-    b_filter = bitset_cardinality (&(b->plan_un.scan.kf_terms));
+    b_filter = bitset_cardinality (& (b->plan_un.scan.kf_terms));
 
     /* STEP 1: take the smaller search condition */
 
@@ -4990,13 +4998,14 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
 	  }
       }
     else
-      {				/* a_range == 0 */
+      {
+	/* a_range == 0 */
 	a_keys = 1;		/* init as full range */
 	if (a_last > 0)
 	  {
-	    if (bitset_cardinality (&(a->plan_un.scan.terms)) > 0)
+	    if (bitset_cardinality (& (a->plan_un.scan.terms)) > 0)
 	      {
-		term = QO_ENV_TERM ((a->info)->env, bitset_first_member (&(a->plan_un.scan.terms)));
+		term = QO_ENV_TERM ((a->info)->env, bitset_first_member (& (a->plan_un.scan.terms)));
 		a_keys = (int) ceil (1.0 / QO_TERM_SELECTIVITY (term));
 	      }
 	    else
@@ -5041,13 +5050,14 @@ qo_plan_cmp (QO_PLAN * a, QO_PLAN * b)
 	  }
       }
     else
-      {				/* b_range == 0 */
+      {
+	/* b_range == 0 */
 	b_keys = 1;		/* init as full range */
 	if (b_last > 0)
 	  {
-	    if (bitset_cardinality (&(b->plan_un.scan.terms)) > 0)
+	    if (bitset_cardinality (& (b->plan_un.scan.terms)) > 0)
 	      {
-		term = QO_ENV_TERM ((b->info)->env, bitset_first_member (&(b->plan_un.scan.terms)));
+		term = QO_ENV_TERM ((b->info)->env, bitset_first_member (& (b->plan_un.scan.terms)));
 		b_keys = (int) ceil (1.0 / QO_TERM_SELECTIVITY (term));
 	      }
 	    else
@@ -5212,7 +5222,7 @@ cost_cmp:
  * b (in) : second plan
  */
 static QO_PLAN_COMPARE_RESULT
-qo_multi_range_opt_plans_cmp (QO_PLAN * a, QO_PLAN * b)
+qo_multi_range_opt_plans_cmp (QO_PLAN *a, QO_PLAN *b)
 {
   QO_PLAN_COMPARE_RESULT temp_res;
 
@@ -5269,8 +5279,8 @@ qo_multi_range_opt_plans_cmp (QO_PLAN * a, QO_PLAN * b)
   assert (qo_is_index_mro_scan (a));
   assert (qo_is_index_mro_scan (b));
 
-  assert (bitset_cardinality (&(a->plan_un.scan.terms)) > 0);
-  assert (bitset_cardinality (&(b->plan_un.scan.terms)) > 0);
+  assert (bitset_cardinality (& (a->plan_un.scan.terms)) > 0);
+  assert (bitset_cardinality (& (b->plan_un.scan.terms)) > 0);
 
   /* choose the plan that also covers all segments */
   temp_res = qo_index_covering_plans_cmp (a, b);
@@ -5289,7 +5299,7 @@ qo_multi_range_opt_plans_cmp (QO_PLAN * a, QO_PLAN * b)
  *   b(in):
  */
 static QO_PLAN_COMPARE_RESULT
-qo_index_covering_plans_cmp (QO_PLAN * a, QO_PLAN * b)
+qo_index_covering_plans_cmp (QO_PLAN *a, QO_PLAN *b)
 {
   int a_range, b_range;		/* num iscan range terms */
 
@@ -5311,8 +5321,8 @@ qo_index_covering_plans_cmp (QO_PLAN * a, QO_PLAN * b)
       return PLAN_COMP_UNK;
     }
 
-  a_range = bitset_cardinality (&(a->plan_un.scan.terms));
-  b_range = bitset_cardinality (&(b->plan_un.scan.terms));
+  a_range = bitset_cardinality (& (a->plan_un.scan.terms));
+  b_range = bitset_cardinality (& (b->plan_un.scan.terms));
 
   assert (a_range >= 0);
   assert (b_range >= 0);
@@ -5353,7 +5363,7 @@ qo_index_covering_plans_cmp (QO_PLAN * a, QO_PLAN * b)
  *   title(in):
  */
 static void
-qo_plan_fprint (QO_PLAN * plan, FILE * f, int howfar, const char *title)
+qo_plan_fprint (QO_PLAN *plan, FILE *f, int howfar, const char *title)
 {
   if (howfar < 0)
     {
@@ -5382,7 +5392,7 @@ qo_plan_fprint (QO_PLAN * plan, FILE * f, int howfar, const char *title)
     howfar += (title_len + INDENT_INCR);
   }
 
-  (*((plan->vtbl)->fprint_fn)) (plan, f, howfar);
+  (* ((plan->vtbl)->fprint_fn)) (plan, f, howfar);
 
   qo_plan_print_projected_segs (plan, f, howfar);
   qo_plan_print_sarged_terms (plan, f, howfar);
@@ -5400,9 +5410,9 @@ qo_plan_fprint (QO_PLAN * plan, FILE * f, int howfar, const char *title)
  *   howfar(in):
  */
 void
-qo_plan_lite_print (QO_PLAN * plan, FILE * f, int howfar)
+qo_plan_lite_print (QO_PLAN *plan, FILE *f, int howfar)
 {
-  (*((plan->vtbl)->info_fn)) (plan, f, howfar);
+  (* ((plan->vtbl)->info_fn)) (plan, f, howfar);
 }
 
 
@@ -5412,7 +5422,7 @@ qo_plan_lite_print (QO_PLAN * plan, FILE * f, int howfar)
  *   plan(in):
  */
 static QO_PLAN *
-qo_plan_finalize (QO_PLAN * plan)
+qo_plan_finalize (QO_PLAN *plan)
 {
   return qo_plan_add_ref (plan);
 }
@@ -5424,7 +5434,7 @@ qo_plan_finalize (QO_PLAN * plan)
  *   plan(in):
  */
 void
-qo_plan_discard (QO_PLAN * plan)
+qo_plan_discard (QO_PLAN *plan)
 {
   if (plan)
     {
@@ -5459,10 +5469,10 @@ qo_plan_discard (QO_PLAN * plan)
  *   parent_data(in):
  */
 static void
-qo_plan_walk (QO_PLAN * plan, void (*child_fn) (QO_PLAN *, void *), void *child_data,
+qo_plan_walk (QO_PLAN *plan, void (*child_fn) (QO_PLAN *, void *), void *child_data,
 	      void (*parent_fn) (QO_PLAN *, void *), void *parent_data)
 {
-  (*(plan->vtbl)->walk_fn) (plan, child_fn, child_data, parent_fn, parent_data);
+  (* (plan->vtbl)->walk_fn) (plan, child_fn, child_data, parent_fn, parent_data);
 }
 
 /*
@@ -5471,7 +5481,7 @@ qo_plan_walk (QO_PLAN * plan, void (*child_fn) (QO_PLAN *, void *), void *child_
  *   plan(in):
  */
 static void
-qo_plan_del_ref_func (QO_PLAN * plan, void *ignore)
+qo_plan_del_ref_func (QO_PLAN *plan, void *ignore)
 {
   qo_plan_del_ref (plan);	/* use the macro */
 }
@@ -5482,10 +5492,10 @@ qo_plan_del_ref_func (QO_PLAN * plan, void *ignore)
  *   plan(in):
  */
 static void
-qo_plan_add_to_free_list (QO_PLAN * plan, void *ignore)
+qo_plan_add_to_free_list (QO_PLAN *plan, void *ignore)
 {
-  bitset_delset (&(plan->sarged_terms));
-  bitset_delset (&(plan->subqueries));
+  bitset_delset (& (plan->sarged_terms));
+  bitset_delset (& (plan->subqueries));
   if (plan->iscan_sort_list)
     {
       parser_free_tree (QO_ENV_PARSER ((plan->info)->env), plan->iscan_sort_list);
@@ -5511,7 +5521,7 @@ qo_plan_add_to_free_list (QO_PLAN * plan, void *ignore)
  *   plan(in):
  */
 static void
-qo_plan_free (QO_PLAN * plan)
+qo_plan_free (QO_PLAN *plan)
 {
   if (plan->refcount != 0)
     {
@@ -5523,7 +5533,7 @@ qo_plan_free (QO_PLAN * plan)
     {
       if ((plan->vtbl)->free_fn)
 	{
-	  (*(plan->vtbl)->free_fn) (plan);
+	  (* (plan->vtbl)->free_fn) (plan);
 	}
 
       qo_plan_walk (plan, qo_plan_del_ref_func, NULL, qo_plan_add_to_free_list, NULL);
@@ -5536,7 +5546,7 @@ qo_plan_free (QO_PLAN * plan)
  *   env(in):
  */
 static void
-qo_plans_init (QO_ENV * env)
+qo_plans_init (QO_ENV *env)
 {
   qo_plan_free_list = NULL;
   qo_plans_allocated = 0;
@@ -5553,7 +5563,7 @@ qo_plans_init (QO_ENV * env)
  *   env(in):
  */
 static void
-qo_plans_teardown (QO_ENV * env)
+qo_plans_teardown (QO_ENV *env)
 {
   while (qo_plan_free_list)
     {
@@ -5575,7 +5585,7 @@ qo_plans_teardown (QO_ENV * env)
  *   f(in):
  */
 void
-qo_plans_stats (FILE * f)
+qo_plans_stats (FILE *f)
 {
   fprintf (f, "%d/%d plans allocated/deallocated\n", qo_plans_allocated, qo_plans_deallocated);
   fprintf (f, "%d/%d plans malloced/demalloced\n", qo_plans_malloced, qo_plans_demalloced);
@@ -5589,7 +5599,7 @@ qo_plans_stats (FILE * f)
  *   output(in): The stream to dump the plan to
  */
 void
-qo_plan_dump (QO_PLAN * plan, FILE * output)
+qo_plan_dump (QO_PLAN *plan, FILE *output)
 {
   int level;
 
@@ -5716,7 +5726,7 @@ qo_plan_set_cost_fn (const char *plan_name, int fn)
  *   planvec(in):
  */
 static void
-qo_init_planvec (QO_PLANVEC * planvec)
+qo_init_planvec (QO_PLANVEC *planvec)
 {
   int i;
 
@@ -5735,7 +5745,7 @@ qo_init_planvec (QO_PLANVEC * planvec)
  *   planvec(in):
  */
 static void
-qo_uninit_planvec (QO_PLANVEC * planvec)
+qo_uninit_planvec (QO_PLANVEC *planvec)
 {
   int i;
 
@@ -5756,7 +5766,7 @@ qo_uninit_planvec (QO_PLANVEC * planvec)
  *   indent(in):
  */
 static void
-qo_dump_planvec (QO_PLANVEC * planvec, FILE * f, int indent)
+qo_dump_planvec (QO_PLANVEC *planvec, FILE *f, int indent)
 {
   int i;
   int positive_indent = indent < 0 ? -indent : indent;
@@ -5781,7 +5791,7 @@ qo_dump_planvec (QO_PLANVEC * planvec, FILE * f, int indent)
  *   plan(in):
  */
 static QO_PLAN_COMPARE_RESULT
-qo_check_planvec (QO_PLANVEC * planvec, QO_PLAN * plan)
+qo_check_planvec (QO_PLANVEC *planvec, QO_PLAN *plan)
 {
   /*
    * Check whether the new plan is definitely better than any of the
@@ -5863,7 +5873,8 @@ qo_check_planvec (QO_PLANVEC * planvec, QO_PLAN * plan)
    * Try to add it to the vector of plans.
    */
   if (!already_retained && !num_eq)
-    {				/* all is PLAN_COMP_UNK */
+    {
+      /* all is PLAN_COMP_UNK */
 
       if (i < NPLANS)
 	{
@@ -5899,13 +5910,15 @@ qo_check_planvec (QO_PLANVEC * planvec, QO_PLAN * plan)
 	      p_tc = p->fixed_cpu_cost + p->fixed_io_cost + p_vc;
 
 	      if (p_vc < vc)
-		{		/* found best variable cost plan */
+		{
+		  /* found best variable cost plan */
 		  best_vc_pid = i;
 		  vc = p_vc;	/* save best variable cost */
 		}
 
 	      if (p_tc < tc)
-		{		/* found best total cost plan */
+		{
+		  /* found best total cost plan */
 		  best_tc_pid = i;
 		  tc = p_tc;	/* save best total cost */
 		}
@@ -5926,13 +5939,15 @@ qo_check_planvec (QO_PLANVEC * planvec, QO_PLAN * plan)
 	      if (i != best_vc_pid && i != best_tc_pid)
 		{
 		  if (p_vc > vc)
-		    {		/* found worst variable cost plan */
+		    {
+		      /* found worst variable cost plan */
 		      worst_vc_pid = i;
 		      vc = p_vc;	/* save worst variable cost */
 		    }
 
 		  if (p_tc > tc)
-		    {		/* found worst total cost plan */
+		    {
+		      /* found worst total cost plan */
 		      worst_tc_pid = i;
 		      tc = p_tc;	/* save worst total cost */
 		    }
@@ -5940,14 +5955,16 @@ qo_check_planvec (QO_PLANVEC * planvec, QO_PLAN * plan)
 	    }
 
 	  if (worst_tc_pid != -1)
-	    {			/* release worst total cost plan */
+	    {
+	      /* release worst total cost plan */
 	      (void) qo_plan_add_ref (plan);
 	      qo_plan_del_ref (planvec->plan[worst_tc_pid]);
 	      planvec->plan[worst_tc_pid] = plan;
 	      already_retained = 1;
 	    }
 	  else if (worst_vc_pid != -1)
-	    {			/* release worst variable cost plan */
+	    {
+	      /* release worst variable cost plan */
 	      (void) qo_plan_add_ref (plan);
 	      qo_plan_del_ref (planvec->plan[worst_vc_pid]);
 	      planvec->plan[worst_vc_pid] = plan;
@@ -5984,7 +6001,7 @@ qo_check_planvec (QO_PLANVEC * planvec, QO_PLAN * plan)
  *   plan(in):
  */
 static QO_PLAN_COMPARE_RESULT
-qo_cmp_planvec (QO_PLANVEC * planvec, QO_PLAN * plan)
+qo_cmp_planvec (QO_PLANVEC *planvec, QO_PLAN *plan)
 {
   int i;
   QO_PLAN_COMPARE_RESULT cmp;
@@ -6012,7 +6029,7 @@ qo_cmp_planvec (QO_PLANVEC * planvec, QO_PLAN * plan)
  *   n(in):
  */
 static QO_PLAN *
-qo_find_best_plan_on_planvec (QO_PLANVEC * planvec, double n)
+qo_find_best_plan_on_planvec (QO_PLANVEC *planvec, double n)
 {
   int i;
   QO_PLAN *best_plan, *plan;
@@ -6063,7 +6080,7 @@ qo_find_best_plan_on_planvec (QO_PLANVEC * planvec, double n)
  *   env(in):
  */
 static void
-qo_info_nodes_init (QO_ENV * env)
+qo_info_nodes_init (QO_ENV *env)
 {
   infos_allocated = 0;
   infos_deallocated = 0;
@@ -6080,7 +6097,7 @@ qo_info_nodes_init (QO_ENV * env)
  *   total_rows(in):
  */
 static QO_INFO *
-qo_alloc_info (QO_PLANNER * planner, BITSET * nodes, BITSET * terms, BITSET * eqclasses, double cardinality,
+qo_alloc_info (QO_PLANNER *planner, BITSET *nodes, BITSET *terms, BITSET *eqclasses, double cardinality,
 	       double total_rows)
 {
   QO_INFO *info;
@@ -6100,10 +6117,10 @@ qo_alloc_info (QO_PLANNER * planner, BITSET * nodes, BITSET * terms, BITSET * eq
   info->env = planner->env;
   info->planner = planner;
 
-  bitset_init (&(info->nodes), planner->env);
-  bitset_init (&(info->terms), planner->env);
-  bitset_init (&(info->eqclasses), planner->env);
-  bitset_init (&(info->projected_segs), planner->env);
+  bitset_init (& (info->nodes), planner->env);
+  bitset_init (& (info->terms), planner->env);
+  bitset_init (& (info->eqclasses), planner->env);
+  bitset_init (& (info->projected_segs), planner->env);
 
   bitset_assign (&info->nodes, nodes);
   bitset_assign (&info->terms, terms);
@@ -6162,7 +6179,7 @@ qo_alloc_info (QO_PLANNER * planner, BITSET * nodes, BITSET * terms, BITSET * eq
  *   info(in):
  */
 static void
-qo_free_info (QO_INFO * info)
+qo_free_info (QO_INFO *info)
 {
   if (info == NULL)
     {
@@ -6171,10 +6188,10 @@ qo_free_info (QO_INFO * info)
 
   qo_detach_info (info);
 
-  bitset_delset (&(info->nodes));
-  bitset_delset (&(info->terms));
-  bitset_delset (&(info->eqclasses));
-  bitset_delset (&(info->projected_segs));
+  bitset_delset (& (info->nodes));
+  bitset_delset (& (info->terms));
+  bitset_delset (& (info->eqclasses));
+  bitset_delset (& (info->projected_segs));
 
   free_and_init (info);
 
@@ -6187,7 +6204,7 @@ qo_free_info (QO_INFO * info)
  *   info(in):
  */
 static void
-qo_detach_info (QO_INFO * info)
+qo_detach_info (QO_INFO *info)
 {
   /*
    * If the node hasn't already been detached, detach it now and give
@@ -6216,13 +6233,13 @@ qo_detach_info (QO_INFO * info)
  *   plan(in):
  */
 static bool
-qo_check_new_best_plan_on_info (QO_INFO * info, QO_PLAN * plan)
+qo_check_new_best_plan_on_info (QO_INFO *info, QO_PLAN *plan)
 {
   QO_PLAN_COMPARE_RESULT cmp;
   QO_EQCLASS *order;
 
   order = plan->order;
-  if (order && bitset_is_empty (&(QO_EQCLASS_SEGS (order))))
+  if (order && bitset_is_empty (& (QO_EQCLASS_SEGS (order))))
     {
       /* Then this "equivalence class" is a phony fabricated especially for a complex merge term. skip out */
       cmp = PLAN_COMP_LT;
@@ -6295,7 +6312,7 @@ qo_check_new_best_plan_on_info (QO_INFO * info, QO_PLAN * plan)
  *   plan(in):
  */
 static int
-qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
+qo_check_plan_on_info (QO_INFO *info, QO_PLAN *plan)
 {
   QO_EQCLASS *plan_order;
   QO_PLAN_COMPARE_RESULT cmp;
@@ -6312,7 +6329,7 @@ qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
 
   /* if the plan is of type QO_SCANMETHOD_INDEX_ORDERBY_SCAN but it doesn't skip the orderby, we release the plan. */
   if (qo_is_iscan_from_orderby (plan)
-      && !(plan->top_rooted ? plan->plan_un.scan.index->head->orderby_skip : qo_plan_is_orderby_skip_candidate (plan)))
+      && ! (plan->top_rooted ? plan->plan_un.scan.index->head->orderby_skip : qo_plan_is_orderby_skip_candidate (plan)))
     {
       qo_plan_release (plan);
       return 0;
@@ -6375,8 +6392,8 @@ qo_check_plan_on_info (QO_INFO * info, QO_PLAN * plan)
  *   idx_join_plan_n(in):
  */
 static QO_PLAN *
-qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TYPE join_type, BITSET * join_terms,
-					BITSET * duj_terms, BITSET * afj_terms, int idx_join_plan_n)
+qo_find_best_nljoin_inner_plan_on_info (QO_PLAN *outer, QO_INFO *info, JOIN_TYPE join_type, BITSET *join_terms,
+					BITSET *duj_terms, BITSET *afj_terms, int idx_join_plan_n)
 {
   QO_PLANVEC *pv;
   QO_PLAN *temp, *best_plan, *inner;
@@ -6404,15 +6421,15 @@ qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TY
   temp->plan_un.join.join_type = join_type;	/* set nl-join type */
   temp->plan_un.join.outer = outer;	/* set outer */
 
-  bitset_init (&(temp->plan_un.join.join_terms), info->env);
-  bitset_init (&(temp->plan_un.join.during_join_terms), info->env);
-  bitset_init (&(temp->plan_un.join.after_join_terms), info->env);
+  bitset_init (& (temp->plan_un.join.join_terms), info->env);
+  bitset_init (& (temp->plan_un.join.during_join_terms), info->env);
+  bitset_init (& (temp->plan_un.join.after_join_terms), info->env);
 
-  bitset_assign (&(temp->plan_un.join.join_terms), join_terms);
+  bitset_assign (& (temp->plan_un.join.join_terms), join_terms);
   if (IS_OUTER_JOIN_TYPE (join_type))
     {
-      bitset_assign (&(temp->plan_un.join.during_join_terms), duj_terms);
-      bitset_assign (&(temp->plan_un.join.after_join_terms), afj_terms);
+      bitset_assign (& (temp->plan_un.join.during_join_terms), duj_terms);
+      bitset_assign (& (temp->plan_un.join.after_join_terms), afj_terms);
     }
 
   temp->multi_range_opt_use = PLAN_MULTI_RANGE_OPT_NO;
@@ -6444,9 +6461,9 @@ qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TY
   /* free temp plan */
   temp->plan_un.join.outer = NULL;
   temp->plan_un.join.inner = NULL;
-  bitset_delset (&(temp->plan_un.join.join_terms));
-  bitset_delset (&(temp->plan_un.join.during_join_terms));
-  bitset_delset (&(temp->plan_un.join.after_join_terms));
+  bitset_delset (& (temp->plan_un.join.join_terms));
+  bitset_delset (& (temp->plan_un.join.during_join_terms));
+  bitset_delset (& (temp->plan_un.join.after_join_terms));
 
   qo_plan_add_to_free_list (temp, NULL);
 
@@ -6461,7 +6478,7 @@ qo_find_best_nljoin_inner_plan_on_info (QO_PLAN * outer, QO_INFO * info, JOIN_TY
  *   n(in):
  */
 static QO_PLAN *
-qo_find_best_plan_on_info (QO_INFO * info, QO_EQCLASS * order, double n)
+qo_find_best_plan_on_info (QO_INFO *info, QO_EQCLASS *order, double n)
 {
   QO_PLANVEC *pv;
 
@@ -6498,8 +6515,8 @@ qo_find_best_plan_on_info (QO_INFO * info, QO_EQCLASS * order, double n)
  *   pinned_subqueries(in):
  */
 static int
-qo_examine_idx_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INFO * inner, BITSET * afj_terms,
-		     BITSET * sarged_terms, BITSET * pinned_subqueries)
+qo_examine_idx_join (QO_INFO *info, JOIN_TYPE join_type, QO_INFO *outer, QO_INFO *inner, BITSET *afj_terms,
+		     BITSET *sarged_terms, BITSET *pinned_subqueries)
 {
   int n = 0;
   QO_NODE *inner_node;
@@ -6507,13 +6524,14 @@ qo_examine_idx_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_IN
   /* check for right outer join; */
   if (join_type == JOIN_RIGHT)
     {
-      if (bitset_cardinality (&(outer->nodes)) != 1)
-	{			/* not single class spec */
+      if (bitset_cardinality (& (outer->nodes)) != 1)
+	{
+	  /* not single class spec */
 	  /* inner of correlated index join should be plain class access */
 	  goto exit;
 	}
 
-      inner_node = QO_ENV_NODE (outer->env, bitset_first_member (&(outer->nodes)));
+      inner_node = QO_ENV_NODE (outer->env, bitset_first_member (& (outer->nodes)));
       if (QO_NODE_HINT (inner_node) & PT_HINT_ORDERED)
 	{
 	  /* join hint: force join left-to-right; skip idx-join because, these are only support left outer join */
@@ -6522,7 +6540,7 @@ qo_examine_idx_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_IN
     }
   else
     {
-      inner_node = QO_ENV_NODE (inner->env, bitset_first_member (&(inner->nodes)));
+      inner_node = QO_ENV_NODE (inner->env, bitset_first_member (& (inner->nodes)));
     }
 
   /* inner is single class spec */
@@ -6535,7 +6553,7 @@ qo_examine_idx_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_IN
       /* join hint: force merge-join; skip idx-join */
       goto exit;
     }
-  else if (!(QO_NODE_HINT (inner_node) & PT_HINT_NO_USE_HASH) && (QO_NODE_HINT (inner_node) & PT_HINT_USE_HASH))
+  else if (! (QO_NODE_HINT (inner_node) & PT_HINT_NO_USE_HASH) && (QO_NODE_HINT (inner_node) & PT_HINT_USE_HASH))
     {
       /* join hint: force hash-join; skip idx-join */
       goto exit;
@@ -6581,9 +6599,9 @@ exit:
  *   idx_join_plan_n(in):
  */
 static int
-qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INFO * inner, BITSET * nl_join_terms,
-		    BITSET * duj_terms, BITSET * afj_terms, BITSET * sarged_terms, BITSET * pinned_subqueries,
-		    int idx_join_plan_n, BITSET * hash_terms)
+qo_examine_nl_join (QO_INFO *info, JOIN_TYPE join_type, QO_INFO *outer, QO_INFO *inner, BITSET *nl_join_terms,
+		    BITSET *duj_terms, BITSET *afj_terms, BITSET *sarged_terms, BITSET *pinned_subqueries,
+		    int idx_join_plan_n, BITSET *hash_terms)
 {
   int n = 0;
   QO_PLAN *outer_plan, *inner_plan;
@@ -6594,7 +6612,7 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
       /* converse outer join type */
       join_type = JOIN_LEFT;
 
-      if (bitset_intersects (sarged_terms, &(info->env->fake_terms)))
+      if (bitset_intersects (sarged_terms, & (info->env->fake_terms)))
 	{
 	  goto exit;
 	}
@@ -6614,9 +6632,10 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
 	  }			/* for (t = ...) */
       }
 
-      if (bitset_cardinality (&(outer->nodes)) == 1)
-	{			/* single class spec */
-	  inner_node = QO_ENV_NODE (outer->env, bitset_first_member (&(outer->nodes)));
+      if (bitset_cardinality (& (outer->nodes)) == 1)
+	{
+	  /* single class spec */
+	  inner_node = QO_ENV_NODE (outer->env, bitset_first_member (& (outer->nodes)));
 	  if (QO_NODE_HINT (inner_node) & PT_HINT_ORDERED)
 	    {
 	      /* join hint: force join left-to-right; skip idx-join because, these are only support left outer join */
@@ -6632,7 +6651,7 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
 	      /* join hint: force idx-join, merge-join; skip nl-join */
 	      goto exit;
 	    }
-	  else if (!(QO_NODE_HINT (inner_node) & PT_HINT_NO_USE_HASH) && (QO_NODE_HINT (inner_node) & PT_HINT_USE_HASH))
+	  else if (! (QO_NODE_HINT (inner_node) & PT_HINT_NO_USE_HASH) && (QO_NODE_HINT (inner_node) & PT_HINT_USE_HASH))
 	    {
 	      /* join hint: force hash-join; skip nl-join */
 	      goto exit;
@@ -6649,8 +6668,8 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
 	  goto exit;
 	}
       inner_plan =
-	qo_find_best_nljoin_inner_plan_on_info (outer_plan, outer, join_type, nl_join_terms, duj_terms, afj_terms,
-						idx_join_plan_n);
+	      qo_find_best_nljoin_inner_plan_on_info (outer_plan, outer, join_type, nl_join_terms, duj_terms, afj_terms,
+		  idx_join_plan_n);
       if (inner_plan == NULL)
 	{
 	  goto exit;
@@ -6659,7 +6678,7 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
   else
     {
       /* At here, inner is single class spec */
-      inner_node = QO_ENV_NODE (inner->env, bitset_first_member (&(inner->nodes)));
+      inner_node = QO_ENV_NODE (inner->env, bitset_first_member (& (inner->nodes)));
       if (QO_NODE_HINT (inner_node) & PT_HINT_USE_NL)
 	{
 	  /* join hint: force nl-join */
@@ -6669,7 +6688,7 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
 	  /* join hint: force idx-join, merge-join; skip nl-join */
 	  goto exit;
 	}
-      else if (!(QO_NODE_HINT (inner_node) & PT_HINT_NO_USE_HASH) && (QO_NODE_HINT (inner_node) & PT_HINT_USE_HASH))
+      else if (! (QO_NODE_HINT (inner_node) & PT_HINT_NO_USE_HASH) && (QO_NODE_HINT (inner_node) & PT_HINT_USE_HASH))
 	{
 	  /* join hint: force hash-join; skip nl-join */
 	  goto exit;
@@ -6685,8 +6704,8 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
 	  goto exit;
 	}
       inner_plan =
-	qo_find_best_nljoin_inner_plan_on_info (outer_plan, inner, join_type, nl_join_terms, duj_terms, afj_terms,
-						idx_join_plan_n);
+	      qo_find_best_nljoin_inner_plan_on_info (outer_plan, inner, join_type, nl_join_terms, duj_terms, afj_terms,
+		  idx_join_plan_n);
       if (inner_plan == NULL)
 	{
 	  goto exit;
@@ -6732,9 +6751,9 @@ qo_examine_nl_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INF
    * produce for this combination.
    */
   n =
-    qo_check_plan_on_info (info,
-			   qo_join_new (info, join_type, QO_JOINMETHOD_NL_JOIN, outer_plan, inner_plan, nl_join_terms,
-					duj_terms, afj_terms, sarged_terms, pinned_subqueries, hash_terms));
+	  qo_check_plan_on_info (info,
+				 qo_join_new (info, join_type, QO_JOINMETHOD_NL_JOIN, outer_plan, inner_plan, nl_join_terms,
+				     duj_terms, afj_terms, sarged_terms, pinned_subqueries, hash_terms));
 
 exit:
 
@@ -6755,8 +6774,8 @@ exit:
  *   pinned_subqueries(in):
  */
 static int
-qo_examine_merge_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INFO * inner, BITSET * sm_join_terms,
-		       BITSET * duj_terms, BITSET * afj_terms, BITSET * sarged_terms, BITSET * pinned_subqueries)
+qo_examine_merge_join (QO_INFO *info, JOIN_TYPE join_type, QO_INFO *outer, QO_INFO *inner, BITSET *sm_join_terms,
+		       BITSET *duj_terms, BITSET *afj_terms, BITSET *sarged_terms, BITSET *pinned_subqueries)
 {
   int n = 0;
   QO_PLAN *outer_plan, *inner_plan;
@@ -6771,7 +6790,7 @@ qo_examine_merge_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_
   /* If any of the sarged terms are fake terms, we can't implement this join as a merge join, because the timing
    * assumptions required by the fake terms won't be satisfied.  Nested loops are the only joins that will work.
    */
-  if (bitset_intersects (sarged_terms, &(info->env->fake_terms)))
+  if (bitset_intersects (sarged_terms, & (info->env->fake_terms)))
     {
       goto exit;
     }
@@ -6813,7 +6832,7 @@ qo_examine_merge_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_
 #endif /* OUTER_MERGE_JOIN_RESTRICTION */
 
   /* At here, inner is single class spec */
-  inner_node = QO_ENV_NODE (inner->env, bitset_first_member (&(inner->nodes)));
+  inner_node = QO_ENV_NODE (inner->env, bitset_first_member (& (inner->nodes)));
 
   if (QO_NODE_HINT (inner_node) & PT_HINT_USE_MERGE)
     {
@@ -6824,7 +6843,7 @@ qo_examine_merge_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_
       /* join hint: force nl-join, idx-join; skip m-join */
       goto exit;
     }
-  else if (!(QO_NODE_HINT (inner_node) & PT_HINT_NO_USE_HASH) && (QO_NODE_HINT (inner_node) & PT_HINT_USE_HASH))
+  else if (! (QO_NODE_HINT (inner_node) & PT_HINT_NO_USE_HASH) && (QO_NODE_HINT (inner_node) & PT_HINT_USE_HASH))
     {
       /* join hint: force hash-join; skip m-join */
       goto exit;
@@ -6886,10 +6905,10 @@ qo_examine_merge_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_
 #endif /* JOIN_FOLLOW_RESTRICTION */
 
   n =
-    qo_check_plan_on_info (info,
-			   qo_join_new (info, join_type, QO_JOINMETHOD_MERGE_JOIN, outer_plan, inner_plan,
-					sm_join_terms, duj_terms, afj_terms, sarged_terms, pinned_subqueries,
-					&empty_terms));
+	  qo_check_plan_on_info (info,
+				 qo_join_new (info, join_type, QO_JOINMETHOD_MERGE_JOIN, outer_plan, inner_plan,
+				     sm_join_terms, duj_terms, afj_terms, sarged_terms, pinned_subqueries,
+				     &empty_terms));
 
 exit:
 
@@ -6910,8 +6929,8 @@ exit:
  *   pinned_subqueries(in):
  */
 static int
-qo_examine_hash_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INFO * inner, BITSET * hash_join_terms,
-		      BITSET * duj_terms, BITSET * afj_terms, BITSET * sarged_terms, BITSET * pinned_subqueries)
+qo_examine_hash_join (QO_INFO *info, JOIN_TYPE join_type, QO_INFO *outer, QO_INFO *inner, BITSET *hash_join_terms,
+		      BITSET *duj_terms, BITSET *afj_terms, BITSET *sarged_terms, BITSET *pinned_subqueries)
 {
   QO_PLAN *outer_plan, *inner_plan;
   QO_NODE *outer_node, *inner_node;
@@ -6970,7 +6989,7 @@ qo_examine_hash_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_I
     }
 
   /* At here, inner is single class spec */
-  inner_node = QO_ENV_NODE (inner->env, bitset_first_member (&(inner->nodes)));
+  inner_node = QO_ENV_NODE (inner->env, bitset_first_member (& (inner->nodes)));
 
   if (QO_NODE_HINT (inner_node) & PT_HINT_NO_USE_HASH)
     {
@@ -7046,10 +7065,10 @@ qo_examine_hash_join (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_I
     }
 
   n =
-    qo_check_plan_on_info (info,
-			   qo_join_new (info, join_type, QO_JOINMETHOD_HASH_JOIN, outer_plan, inner_plan,
-					hash_join_terms, duj_terms, afj_terms, sarged_terms, pinned_subqueries,
-					hash_join_terms));
+	  qo_check_plan_on_info (info,
+				 qo_join_new (info, join_type, QO_JOINMETHOD_HASH_JOIN, outer_plan, inner_plan,
+				     hash_join_terms, duj_terms, afj_terms, sarged_terms, pinned_subqueries,
+				     hash_join_terms));
 
 exit:
   return n;
@@ -7083,8 +7102,8 @@ exit:
  *			}
  */
 static int
-qo_examine_correlated_index (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * outer, QO_INFO * inner, BITSET * afj_terms,
-			     BITSET * sarged_terms, BITSET * pinned_subqueries)
+qo_examine_correlated_index (QO_INFO *info, JOIN_TYPE join_type, QO_INFO *outer, QO_INFO *inner, BITSET *afj_terms,
+			     BITSET *sarged_terms, BITSET *pinned_subqueries)
 {
   QO_NODE *nodep;
   QO_NODE_INDEX *node_indexp;
@@ -7117,7 +7136,7 @@ qo_examine_correlated_index (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * oute
 #endif /* JOIN_FOLLOW_RESTRICTION */
 
   /* inner node and its indexes */
-  nodep = &info->planner->node[bitset_first_member (&(inner->nodes))];
+  nodep = &info->planner->node[bitset_first_member (& (inner->nodes))];
   node_indexp = QO_NODE_INDEXES (nodep);
   if (node_indexp == NULL)
     {
@@ -7150,7 +7169,7 @@ qo_examine_correlated_index (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * oute
     }
 
   /* finally, combine inner plan's 'sarg term' together */
-  bitset_union (&indexable_terms, &(QO_NODE_SARGS (nodep)));
+  bitset_union (&indexable_terms, & (QO_NODE_SARGS (nodep)));
 
   num_only_args = 0;		/* init */
 
@@ -7169,10 +7188,10 @@ qo_examine_correlated_index (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * oute
 	}
 
       /* the index has terms which are a subset of the terms that we're interested in */
-      if (bitset_intersects (&indexable_terms, &(index_entryp->terms)))
+      if (bitset_intersects (&indexable_terms, & (index_entryp->terms)))
 	{
 
-	  if (!bitset_intersects (sarged_terms, &(index_entryp->terms)))
+	  if (!bitset_intersects (sarged_terms, & (index_entryp->terms)))
 	    {
 	      /* there is not join-edge, only inner sargs */
 	      num_only_args++;
@@ -7181,8 +7200,8 @@ qo_examine_correlated_index (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * oute
 
 	  /* generate join index scan using 'ni_entryp' */
 	  n +=
-	    qo_generate_join_index_scan (info, join_type, outer_plan, inner, nodep, ni_entryp, &indexable_terms,
-					 afj_terms, sarged_terms, pinned_subqueries);
+		  qo_generate_join_index_scan (info, join_type, outer_plan, inner, nodep, ni_entryp, &indexable_terms,
+					       afj_terms, sarged_terms, pinned_subqueries);
 	}
     }
 
@@ -7190,7 +7209,8 @@ qo_examine_correlated_index (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * oute
     {
       /* join hint: force idx-join */
       if (n == 0 && num_only_args)
-	{			/* not found 'idx-join' plan */
+	{
+	  /* not found 'idx-join' plan */
 	  /* Re-Iterate */
 	  for (i = 0; i < QO_NI_N (node_indexp); i++)
 	    {
@@ -7204,9 +7224,9 @@ qo_examine_correlated_index (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * oute
 		}
 
 	      /* the index has terms which are a subset of the terms that we're intersted in */
-	      if (bitset_intersects (&indexable_terms, &(index_entryp->terms)))
+	      if (bitset_intersects (&indexable_terms, & (index_entryp->terms)))
 		{
-		  if (bitset_intersects (sarged_terms, &(index_entryp->terms)))
+		  if (bitset_intersects (sarged_terms, & (index_entryp->terms)))
 		    {
 		      /* there is join-edge; already examined */
 		      continue;
@@ -7214,8 +7234,8 @@ qo_examine_correlated_index (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * oute
 
 		  /* generate join index scan using 'ni_entryp' */
 		  n +=
-		    qo_generate_join_index_scan (info, join_type, outer_plan, inner, nodep, ni_entryp, &indexable_terms,
-						 afj_terms, sarged_terms, pinned_subqueries);
+			  qo_generate_join_index_scan (info, join_type, outer_plan, inner, nodep, ni_entryp, &indexable_terms,
+						       afj_terms, sarged_terms, pinned_subqueries);
 		}
 	    }
 	}
@@ -7236,8 +7256,8 @@ qo_examine_correlated_index (QO_INFO * info, JOIN_TYPE join_type, QO_INFO * oute
  *   pinned_subqueries(in):
  */
 static int
-qo_examine_follow (QO_INFO * info, QO_TERM * path_term, QO_INFO * head_info, BITSET * sarged_terms,
-		   BITSET * pinned_subqueries)
+qo_examine_follow (QO_INFO *info, QO_TERM *path_term, QO_INFO *head_info, BITSET *sarged_terms,
+		   BITSET *pinned_subqueries)
 {
   PT_NODE *entity_spec;
   /*
@@ -7253,7 +7273,7 @@ qo_examine_follow (QO_INFO * info, QO_TERM * path_term, QO_INFO * head_info, BIT
 
   return qo_check_plan_on_info (info,
 				qo_follow_new (info, qo_find_best_plan_on_info (head_info, QO_UNORDERED, 1.0),
-					       path_term, sarged_terms, pinned_subqueries));
+				    path_term, sarged_terms, pinned_subqueries));
 
 }
 
@@ -7266,7 +7286,7 @@ qo_examine_follow (QO_INFO * info, QO_TERM * path_term, QO_INFO * head_info, BIT
  *   projected(in):
  */
 static void
-qo_compute_projected_segs (QO_PLANNER * planner, BITSET * nodes, BITSET * terms, BITSET * projected)
+qo_compute_projected_segs (QO_PLANNER *planner, BITSET *nodes, BITSET *terms, BITSET *projected)
 {
   /*
    * Figure out which of the attributes of the nodes joined by the
@@ -7283,21 +7303,23 @@ qo_compute_projected_segs (QO_PLANNER * planner, BITSET * nodes, BITSET * terms,
 
   BITSET_CLEAR (*projected);
   bitset_init (&required, planner->env);
-  bitset_assign (&required, &(planner->final_segs));
+  bitset_assign (&required, & (planner->final_segs));
 
   for (i = 0; i < (signed) planner->T; i++)
     {
       if (!BITSET_MEMBER (*terms, i))
 	{
 	  term = &planner->term[i];
-	  bitset_union (&required, &(QO_TERM_SEGS (term)));
+	  bitset_union (&required, & (QO_TERM_SEGS (term)));
 	}
     }
 
   for (i = 0; i < (signed) planner->N; ++i)
     {
       if (BITSET_MEMBER (*nodes, i))
-	bitset_union (projected, &(QO_NODE_SEGS (&planner->node[i])));
+	{
+	  bitset_union (projected, & (QO_NODE_SEGS (&planner->node[i])));
+	}
     }
 
   bitset_intersect (projected, &required);
@@ -7311,7 +7333,7 @@ qo_compute_projected_segs (QO_PLANNER * planner, BITSET * nodes, BITSET * terms,
  *   segset(in):
  */
 static int
-qo_compute_projected_size (QO_PLANNER * planner, BITSET * segset)
+qo_compute_projected_size (QO_PLANNER *planner, BITSET *segset)
 {
   BITSET_ITERATOR si;
   int i;
@@ -7340,7 +7362,7 @@ qo_compute_projected_size (QO_PLANNER * planner, BITSET * segset)
  *   f(in):
  */
 static void
-qo_dump_info (QO_INFO * info, FILE * f)
+qo_dump_info (QO_INFO *info, FILE *f)
 {
   /*
    * Dump the contents of this node for debugging scrutiny.
@@ -7349,7 +7371,7 @@ qo_dump_info (QO_INFO * info, FILE * f)
   int i;
 
   fputs ("  projected segments: ", f);
-  bitset_print (&(info->projected_segs), f);
+  bitset_print (& (info->projected_segs), f);
   fputs ("\n", f);
 
   fputs ("  best: ", f);
@@ -7384,7 +7406,7 @@ qo_dump_info (QO_INFO * info, FILE * f)
  *   f(in):
  */
 void
-qo_info_stats (FILE * f)
+qo_info_stats (FILE *f)
 {
   fprintf (f, "%d/%d info nodes allocated/deallocated\n", infos_allocated, infos_deallocated);
 }
@@ -7395,7 +7417,7 @@ qo_info_stats (FILE * f)
  *   env(in):
  */
 static QO_PLANNER *
-qo_alloc_planner (QO_ENV * env)
+qo_alloc_planner (QO_ENV *env)
 {
   int i;
   QO_PLANNER *planner;
@@ -7434,11 +7456,13 @@ qo_alloc_planner (QO_ENV * env)
   planner->P = env->npartitions;
   planner->partition = env->partitions;
 
-  bitset_init (&(planner->final_segs), env);
-  bitset_assign (&(planner->final_segs), &(env->final_segs));
-  bitset_init (&(planner->all_subqueries), env);
+  bitset_init (& (planner->final_segs), env);
+  bitset_assign (& (planner->final_segs), & (env->final_segs));
+  bitset_init (& (planner->all_subqueries), env);
   for (i = 0; i < (signed) planner->Q; ++i)
-    bitset_add (&(planner->all_subqueries), i);
+    {
+      bitset_add (& (planner->all_subqueries), i);
+    }
 
   planner->node_info = NULL;
   planner->join_info = NULL;
@@ -7459,10 +7483,12 @@ qo_alloc_planner (QO_ENV * env)
  *   planner(in):
  */
 void
-qo_planner_free (QO_PLANNER * planner)
+qo_planner_free (QO_PLANNER *planner)
 {
   if (planner->cleanup_needed)
-    qo_clean_planner (planner);
+    {
+      qo_clean_planner (planner);
+    }
 
   qo_plan_del_ref (planner->worst_plan);
 
@@ -7503,7 +7529,7 @@ qo_planner_free (QO_PLANNER * planner)
  *   f(in):
  */
 static void
-qo_dump_planner_info (QO_PLANNER * planner, QO_PARTITION * partition, FILE * f)
+qo_dump_planner_info (QO_PLANNER *planner, QO_PARTITION *partition, FILE *f)
 {
   int i, M;
   QO_INFO *info;
@@ -7525,7 +7551,7 @@ qo_dump_planner_info (QO_PLANNER * planner, QO_PARTITION * partition, FILE * f)
 	}
     }
 
-  if (!bitset_is_empty (&(QO_PARTITION_EDGES (partition))))
+  if (!bitset_is_empty (& (QO_PARTITION_EDGES (partition))))
     {
       fputs ("\nJoin info maps:\n", f);
       /* in current implementation, join_info[0..2] does not used */
@@ -7538,7 +7564,7 @@ qo_dump_planner_info (QO_PLANNER * planner, QO_PARTITION * partition, FILE * f)
 	    {
 	      fputs ("join_info[", f);
 	      prefix = "";	/* init */
-	      for (t = bitset_iterate (&(info->nodes), &iter); t != -1; t = bitset_next_member (&iter))
+	      for (t = bitset_iterate (& (info->nodes), &iter); t != -1; t = bitset_next_member (&iter))
 		{
 		  fprintf (f, "%s%d", prefix, QO_NODE_IDX (QO_ENV_NODE (planner->env, t)));
 		  prefix = ",";
@@ -7577,10 +7603,10 @@ qo_dump_planner_info (QO_PLANNER * planner, QO_PARTITION * partition, FILE * f)
  * assume the original NDV relationship is maintained.
  */
 static void
-qo_get_term_hit_prob (QO_TERM * term, QO_INFO * head_info, QO_INFO * tail_info, QO_ENV * env,
+qo_get_term_hit_prob (QO_TERM *term, QO_INFO *head_info, QO_INFO *tail_info, QO_ENV *env,
 		      double *out_head_factor, double *out_tail_factor)
 {
-  const BITSET *term_segs = (const BITSET *) &(term->segments);
+  const BITSET *term_segs = (const BITSET *) & (term->segments);
   BITSET_ITERATOR seg_iter;
   int seg_idx;
   QO_SEGMENT *head_seg = NULL, *tail_seg = NULL;
@@ -7636,10 +7662,10 @@ qo_get_term_hit_prob (QO_TERM * term, QO_INFO * head_info, QO_INFO * tail_info, 
 }
 
 static void
-planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM hint, QO_NODE * head_node,
-		    QO_NODE * tail_node, BITSET * visited_nodes, BITSET * visited_rel_nodes, BITSET * visited_terms,
-		    BITSET * nested_path_nodes, BITSET * remaining_nodes, BITSET * remaining_terms,
-		    BITSET * remaining_subqueries, int num_path_inner)
+planner_visit_node (QO_PLANNER *planner, QO_PARTITION *partition, PT_HINT_ENUM hint, QO_NODE *head_node,
+		    QO_NODE *tail_node, BITSET *visited_nodes, BITSET *visited_rel_nodes, BITSET *visited_terms,
+		    BITSET *nested_path_nodes, BITSET *remaining_nodes, BITSET *remaining_terms,
+		    BITSET *remaining_subqueries, int num_path_inner)
 {
   JOIN_TYPE join_type = NO_JOIN;
   QO_TERM *follow_term = NULL;
@@ -7678,9 +7704,11 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
     }
 
   if (num_path_inner)
-    {				/* check for path connected nodes */
+    {
+      /* check for path connected nodes */
       if (bitset_is_empty (nested_path_nodes))
-	{			/* not yet assign path connected nodes */
+	{
+	  /* not yet assign path connected nodes */
 	  int found_num, found_idx;
 
 	  for (i = bitset_iterate (remaining_terms, &bi); i != -1; i = bitset_next_member (&bi))
@@ -7744,7 +7772,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	    }
 	}
       else
-	{			/* already assign path connected nodes */
+	{
+	  /* already assign path connected nodes */
 	  if (BITSET_MEMBER (*nested_path_nodes, QO_NODE_IDX (tail_node)))
 	    {
 	      /* remove tail_node from path connected nodes */
@@ -7800,7 +7829,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 
       /* STEP 2: set terms for join_info */
       /* set info terms */
-      bitset_assign (&info_terms, &(new_info->terms));
+      bitset_assign (&info_terms, & (new_info->terms));
       bitset_difference (&info_terms, visited_terms);
 
       /* extract visited info terms */
@@ -7814,7 +7843,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	for (i = bitset_iterate (remaining_subqueries, &bi); i != -1; i = bitset_next_member (&bi))
 	  {
 	    subq = &planner->subqueries[i];
-	    if (bitset_subset (visited_nodes, &(subq->nodes)) && bitset_subset (visited_terms, &(subq->terms)))
+	    if (bitset_subset (visited_nodes, & (subq->nodes)) && bitset_subset (visited_terms, & (subq->terms)))
 	      {
 		bitset_add (&pinned_subqueries, i);
 	      }
@@ -7829,7 +7858,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 
   /* extract terms of the tail_info subplan. this is necessary to ensure that we are aware of any terms that have been
    * sarged by the subplans */
-  bitset_union (&info_terms, &(tail_info->terms));
+  bitset_union (&info_terms, & (tail_info->terms));
 
   /* extract visited info terms */
   bitset_union (visited_terms, &info_terms);
@@ -7849,13 +7878,13 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 
 	if (QO_TERM_NOMINAL_SEG (term))
 	  {
-	    bitset_union (&visited_segs, &(QO_TERM_SEGS (term)));
+	    bitset_union (&visited_segs, & (QO_TERM_SEGS (term)));
 	  }
       }
 
     retry_cnt = 0;		/* init */
 
-  retry_join_edge:
+retry_join_edge:
 
     edge_cnt = path_cnt = 0;	/* init */
 
@@ -7865,7 +7894,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	term = QO_ENV_TERM (planner->env, i);
 
 	/* check term nodes */
-	if (!bitset_subset (visited_nodes, &(QO_TERM_NODES (term))))
+	if (!bitset_subset (visited_nodes, & (QO_TERM_NODES (term))))
 	  {
 	    continue;
 	  }
@@ -7885,7 +7914,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	      }
 
 	    if (j == -1)
-	      {			/* out of location */
+	      {
+		/* out of location */
 		continue;
 	      }
 	  }
@@ -7898,7 +7928,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	    if (QO_TERM_CLASS (term) == QO_TC_PATH)
 	      {
 		if (retry_cnt == 0)
-		  {		/* is the first stage */
+		  {
+		    /* is the first stage */
 		    /* need to check the direction; head -> tail */
 		    if (QO_NODE_IDX (QO_TERM_TAIL (term)) == QO_NODE_IDX (tail_node))
 		      {
@@ -7939,7 +7970,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 		/* The dummy join term is excluded from the outer join check. */
 	      }
 	    else
-	      {			/* already assigned */
+	      {
+		/* already assigned */
 		if (IS_OUTER_JOIN_TYPE (join_type))
 		  {
 		    /* outer join type must be the same */
@@ -7970,7 +8002,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 
 	      case QO_TC_PATH:
 		if (follow_term == NULL)
-		  {		/* get the first PATH term idx */
+		  {
+		    /* get the first PATH term idx */
 		    follow_term = term;
 		    /* for path-term, if join type is not outer join, we can use idx-join, nl-join */
 		    if (QO_TERM_JOIN_TYPE (follow_term) == JOIN_INNER)
@@ -7989,7 +8022,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 		      }
 		  }
 		else
-		  {		/* found another PATH term */
+		  {
+		    /* found another PATH term */
 		    /* unknown error */
 		    QO_ASSERT (planner->env, UNEXPECTED_CASE);
 		  }
@@ -8005,7 +8039,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 		      }
 		    else
 		      {
-			bitset_union (&visited_segs, &(QO_TERM_SEGS (term)));
+			bitset_union (&visited_segs, & (QO_TERM_SEGS (term)));
 		      }
 		  }
 
@@ -8023,9 +8057,11 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 			bitset_add (&sm_join_terms, i);
 		      }
 		    else
-		      {		/* non-eq edge */
+		      {
+			/* non-eq edge */
 			if (IS_OUTER_JOIN_TYPE (join_type) && QO_ON_COND_TERM (term))
-			  {	/* ON clause */
+			  {
+			    /* ON clause */
 			    bitset_add (&duj_terms, i);	/* need for m-join */
 			  }
 		      }
@@ -8058,7 +8094,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 		 * graph permutations(i.e., we have considered every one of the nodes). only include after-join term
 		 * for this plan.
 		 */
-		if (!bitset_is_equivalent (visited_nodes, &(QO_PARTITION_NODES (partition))))
+		if (!bitset_is_equivalent (visited_nodes, & (QO_PARTITION_NODES (partition))))
 		  {
 		    continue;
 		  }
@@ -8067,7 +8103,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	    else if (QO_TERM_CLASS (term) == QO_TC_OTHER)
 	      {
 		if (IS_OUTER_JOIN_TYPE (join_type) && QO_ON_COND_TERM (term))
-		  {		/* ON clause */
+		  {
+		    /* ON clause */
 		    bitset_add (&duj_terms, i);
 		  }
 	      }
@@ -8086,7 +8123,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
     if (edge_cnt == 0)
       {
 	if (retry_cnt == 0)
-	  {			/* is the first stage */
+	  {
+	    /* is the first stage */
 	    if (path_cnt > 0)
 	      {
 		/* there is only path edge and the direction is reversed */
@@ -8154,7 +8192,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
     for (i = bitset_iterate (remaining_subqueries, &bi); i != -1; i = bitset_next_member (&bi))
       {
 	subq = &planner->subqueries[i];
-	if (bitset_subset (visited_nodes, &(subq->nodes)) && bitset_subset (visited_terms, &(subq->terms)))
+	if (bitset_subset (visited_nodes, & (subq->nodes)) && bitset_subset (visited_terms, & (subq->terms)))
 	  {
 	    bitset_add (&pinned_subqueries, i);
 	  }
@@ -8195,7 +8233,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	}
 
       if (cardinality != 0)
-	{			/* not empty */
+	{
+	  /* not empty */
 	  cardinality = MAX (1.0, cardinality);
 	  for (i = bitset_iterate (&sarged_terms, &bi); i != -1; i = bitset_next_member (&bi))
 	    {
@@ -8205,7 +8244,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 		  /* single-fetch */
 		  cardinality = head_info->cardinality;
 		  if (cardinality != 0)
-		    {		/* not empty */
+		    {
+		      /* not empty */
 		      cardinality = MAX (1.0, cardinality);
 		    }
 		}
@@ -8241,8 +8281,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	    }
 	}
 
-      bitset_assign (&eqclasses, &(head_info->eqclasses));
-      bitset_union (&eqclasses, &(tail_info->eqclasses));
+      bitset_assign (&eqclasses, & (head_info->eqclasses));
+      bitset_union (&eqclasses, & (tail_info->eqclasses));
 
       head_info->hit_prob = head_hit_prob;
       tail_info->hit_prob = tail_hit_prob;
@@ -8260,7 +8300,7 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	}
 
       new_info = planner->join_info[QO_INFO_INDEX (QO_PARTITION_M_OFFSET (partition), *visited_rel_nodes)] =
-	qo_alloc_info (planner, visited_nodes, visited_terms, &eqclasses, cardinality, total_rows);
+			 qo_alloc_info (planner, visited_nodes, visited_terms, &eqclasses, cardinality, total_rows);
 
       bitset_delset (&eqclasses);
     }
@@ -8290,8 +8330,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	if (idx_join_cnt)
 	  {
 	    idx_join_plan_n =
-	      qo_examine_idx_join (new_info, join_type, head_info, tail_info, &afj_terms, &sarged_terms,
-				   &pinned_subqueries);
+		    qo_examine_idx_join (new_info, join_type, head_info, tail_info, &afj_terms, &sarged_terms,
+					 &pinned_subqueries);
 	    kept += idx_join_plan_n;
 	  }
 #endif /* CORRELATED_INDEX */
@@ -8302,16 +8342,16 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	/* If the characteristics for mergeable terms are changed, the logic for hash terms should be separated. */
 	/* mergeable term : equi-term, symmetrical term, e.g. TBL1.a = TBL2.a, function(TAB1.a) = function(TAB2.a) */
 	kept +=
-	  qo_examine_nl_join (new_info, join_type, head_info, tail_info, &nl_join_terms, &duj_terms, &afj_terms,
-			      &sarged_terms, &pinned_subqueries, idx_join_plan_n, &sm_join_terms);
+		qo_examine_nl_join (new_info, join_type, head_info, tail_info, &nl_join_terms, &duj_terms, &afj_terms,
+				    &sarged_terms, &pinned_subqueries, idx_join_plan_n, &sm_join_terms);
 
 #if 1				/* MERGE_JOINS */
 	/* STEP 5-4: examine merge-join */
 	if (!bitset_is_empty (&sm_join_terms))
 	  {
 	    kept +=
-	      qo_examine_merge_join (new_info, join_type, head_info, tail_info, &sm_join_terms, &duj_terms, &afj_terms,
-				     &sarged_terms, &pinned_subqueries);
+		    qo_examine_merge_join (new_info, join_type, head_info, tail_info, &sm_join_terms, &duj_terms, &afj_terms,
+					   &sarged_terms, &pinned_subqueries);
 	  }
 #endif /* MERGE_JOINS */
 
@@ -8327,8 +8367,8 @@ planner_visit_node (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM
 	     * mergeable term: equi-term, symmetrical term, e.g. TBL1.a = TBL2.a, function(TAB1.a) = function(TAB2.a)
 	     */
 	    kept +=
-	      qo_examine_hash_join (new_info, join_type, head_info, tail_info, &sm_join_terms, &duj_terms, &afj_terms,
-				    &sarged_terms, &pinned_subqueries);
+		    qo_examine_hash_join (new_info, join_type, head_info, tail_info, &sm_join_terms, &duj_terms, &afj_terms,
+					  &sarged_terms, &pinned_subqueries);
 	  }
 #endif /* HASH_JOINS */
       }
@@ -8368,7 +8408,8 @@ go_ahead_subvisit:
       new_plan = qo_find_best_plan_on_info (new_info, QO_UNORDERED, 1.0);
       best_plan = qo_find_best_plan_on_info (planner->best_info, QO_UNORDERED, 1.0);
       if (best_plan == NULL || new_plan == NULL)
-	{			/* unknown error */
+	{
+	  /* unknown error */
 	  goto wrapup;		/* give up */
 	}
       QO_PLAN_COMPARE_RESULT cmp = qo_plan_cmp (best_plan, new_plan);
@@ -8385,14 +8426,14 @@ go_ahead_subvisit:
 	  node = QO_ENV_NODE (planner->env, i);
 
 	  /* node dependency check; */
-	  if (!bitset_subset (visited_nodes, &(QO_NODE_DEP_SET (node))))
+	  if (!bitset_subset (visited_nodes, & (QO_NODE_DEP_SET (node))))
 	    {
 	      /* node represents dependent tables, so there is no way this combination can work in isolation.  Give up
 	       * so we can try some other combinations.
 	       */
 	      continue;
 	    }
-	  if (!bitset_subset (visited_nodes, &(QO_NODE_OUTER_DEP_SET (node))))
+	  if (!bitset_subset (visited_nodes, & (QO_NODE_OUTER_DEP_SET (node))))
 	    {
 	      /* All previous nodes participating in outer join spec should be joined before. QO_NODE_OUTER_DEP_SET()
 	       * represents all previous nodes which are dependents on the node.
@@ -8445,7 +8486,7 @@ wrapup:
  *   nodeset(in):
  */
 static double
-planner_nodeset_join_cost (QO_PLANNER * planner, BITSET * nodeset)
+planner_nodeset_join_cost (QO_PLANNER *planner, BITSET *nodeset)
 {
   int i;
   BITSET_ITERATOR bi;
@@ -8465,7 +8506,8 @@ planner_nodeset_join_cost (QO_PLANNER * planner, BITSET * nodeset)
       plan = qo_find_best_plan_on_info (info, QO_UNORDERED, 1.0);
 
       if (plan == NULL)
-	{			/* something wrong */
+	{
+	  /* something wrong */
 	  continue;		/* give up */
 	}
 
@@ -8482,7 +8524,7 @@ planner_nodeset_join_cost (QO_PLANNER * planner, BITSET * nodeset)
 	{
 	  /* join hint: force idx-join, nl-join */
 	}
-      else if (!(QO_NODE_HINT (node) & PT_HINT_NO_USE_HASH) && (QO_NODE_HINT (node) & PT_HINT_USE_HASH))
+      else if (! (QO_NODE_HINT (node) & PT_HINT_NO_USE_HASH) && (QO_NODE_HINT (node) & PT_HINT_USE_HASH))
 	{
 	  /* join hint: force hash-join */
 	}
@@ -8543,10 +8585,10 @@ planner_nodeset_join_cost (QO_PLANNER * planner, BITSET * nodeset)
  *   node_idxp(in):
  */
 static void
-planner_permutate (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM hint, QO_NODE * prev_head_node,
-		   BITSET * visited_nodes, BITSET * visited_rel_nodes, BITSET * visited_terms,
-		   BITSET * nested_path_nodes, BITSET * remaining_nodes, BITSET * remaining_terms,
-		   BITSET * remaining_subqueries, int num_path_inner, int *node_idxp)
+planner_permutate (QO_PLANNER *planner, QO_PARTITION *partition, PT_HINT_ENUM hint, QO_NODE *prev_head_node,
+		   BITSET *visited_nodes, BITSET *visited_rel_nodes, BITSET *visited_terms,
+		   BITSET *nested_path_nodes, BITSET *remaining_nodes, BITSET *remaining_terms,
+		   BITSET *remaining_subqueries, int num_path_inner, int *node_idxp)
 {
   int i, j;
   BITSET_ITERATOR bi, bj;
@@ -8572,14 +8614,14 @@ planner_permutate (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM 
       head_node = QO_ENV_NODE (planner->env, i);
 
       /* head node dependency check; */
-      if (!bitset_subset (visited_nodes, &(QO_NODE_DEP_SET (head_node))))
+      if (!bitset_subset (visited_nodes, & (QO_NODE_DEP_SET (head_node))))
 	{
 	  /* head node represents dependent tables, so there is no way this combination can work in isolation.  Give up
 	   * so we can try some other combinations.
 	   */
 	  continue;
 	}
-      if (!bitset_subset (visited_nodes, &(QO_NODE_OUTER_DEP_SET (head_node))))
+      if (!bitset_subset (visited_nodes, & (QO_NODE_OUTER_DEP_SET (head_node))))
 	{
 	  /* All previous nodes participating in outer join spec should be joined before. QO_NODE_OUTER_DEP_SET()
 	   * represents all previous nodes which are dependents on the node.
@@ -8588,7 +8630,8 @@ planner_permutate (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM 
 	}
 
       if (bitset_is_empty (visited_nodes))
-	{			/* not found outermost nodes */
+	{
+	  /* not found outermost nodes */
 
 	  head_info = planner->node_info[QO_NODE_IDX (head_node)];
 
@@ -8597,8 +8640,8 @@ planner_permutate (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM 
 	  bitset_add (visited_rel_nodes, QO_NODE_REL_IDX (head_node));
 	  bitset_remove (remaining_nodes, QO_NODE_IDX (head_node));
 
-	  bitset_union (visited_terms, &(head_info->terms));
-	  bitset_difference (remaining_terms, &(head_info->terms));
+	  bitset_union (visited_terms, & (head_info->terms));
+	  bitset_difference (remaining_terms, & (head_info->terms));
 
 	  for (j = bitset_iterate (remaining_nodes, &bj); j != -1; j = bitset_next_member (&bj))
 	    {
@@ -8606,11 +8649,11 @@ planner_permutate (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM 
 	      tail_node = QO_ENV_NODE (planner->env, j);
 
 	      /* tail node dependency check; */
-	      if (!bitset_subset (visited_nodes, &(QO_NODE_DEP_SET (tail_node))))
+	      if (!bitset_subset (visited_nodes, & (QO_NODE_DEP_SET (tail_node))))
 		{
 		  continue;
 		}
-	      if (!bitset_subset (visited_nodes, &(QO_NODE_OUTER_DEP_SET (tail_node))))
+	      if (!bitset_subset (visited_nodes, & (QO_NODE_OUTER_DEP_SET (tail_node))))
 		{
 		  continue;
 		}
@@ -8633,12 +8676,13 @@ planner_permutate (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM 
 	  BITSET_CLEAR (*visited_rel_nodes);
 	  bitset_add (remaining_nodes, QO_NODE_IDX (head_node));
 
-	  bitset_difference (visited_terms, &(head_info->terms));
-	  bitset_union (remaining_terms, &(head_info->terms));
+	  bitset_difference (visited_terms, & (head_info->terms));
+	  bitset_union (remaining_terms, & (head_info->terms));
 
 	}
       else
-	{			/* found some outermost nodes */
+	{
+	  /* found some outermost nodes */
 
 	  BITSET_CLEAR (*nested_path_nodes);
 
@@ -8648,28 +8692,31 @@ planner_permutate (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM 
 	}
 
       if (node_idxp)
-	{			/* is partial node visit */
+	{
+	  /* is partial node visit */
 	  best_info = planner->best_info;
 	  if (best_info == NULL)
-	    {			/* not found best plan */
+	    {
+	      /* not found best plan */
 	      continue;		/* skip and go ahead */
 	    }
 
 	  best_plan = qo_find_best_plan_on_info (best_info, QO_UNORDERED, 1.0);
 
 	  if (best_plan == NULL)
-	    {			/* unknown error */
+	    {
+	      /* unknown error */
 	      break;		/* give up */
 	    }
 
 	  /* set best plan's cost */
 	  best_cost =
-	    best_plan->fixed_cpu_cost + best_plan->fixed_io_cost + best_plan->variable_cpu_cost +
-	    best_plan->variable_io_cost;
+		  best_plan->fixed_cpu_cost + best_plan->fixed_io_cost + best_plan->variable_cpu_cost +
+		  best_plan->variable_io_cost;
 
 	  /* apply rest nodes's cost */
 	  bitset_assign (&rest_nodes, remaining_nodes);
-	  bitset_difference (&rest_nodes, &(best_info->nodes));
+	  bitset_difference (&rest_nodes, & (best_info->nodes));
 	  best_cost += planner_nodeset_join_cost (planner, &rest_nodes);
 
 	  if (prev_best_cost == -1.0	/* the first time */
@@ -8690,7 +8737,8 @@ planner_permutate (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM 
     }
 
   if (node_idxp)
-    {				/* is partial node visit */
+    {
+      /* is partial node visit */
       planner->best_info = NULL;	/* clear */
     }
 
@@ -8705,7 +8753,7 @@ planner_permutate (QO_PLANNER * planner, QO_PARTITION * partition, PT_HINT_ENUM 
  *   env(in):
  */
 QO_PLAN *
-qo_planner_search (QO_ENV * env)
+qo_planner_search (QO_ENV *env)
 {
   QO_PLANNER *planner;
   QO_PLAN *plan;
@@ -8742,9 +8790,9 @@ qo_planner_search (QO_ENV * env)
  *   pinned_subqueries(in):
  */
 static int
-qo_generate_join_index_scan (QO_INFO * infop, JOIN_TYPE join_type, QO_PLAN * outer_plan, QO_INFO * inner,
-			     QO_NODE * nodep, QO_NODE_INDEX_ENTRY * ni_entryp, BITSET * indexable_terms,
-			     BITSET * afj_terms, BITSET * sarged_terms, BITSET * pinned_subqueries)
+qo_generate_join_index_scan (QO_INFO *infop, JOIN_TYPE join_type, QO_PLAN *outer_plan, QO_INFO *inner,
+			     QO_NODE *nodep, QO_NODE_INDEX_ENTRY *ni_entryp, BITSET *indexable_terms,
+			     BITSET *afj_terms, BITSET *sarged_terms, BITSET *pinned_subqueries)
 {
   QO_ENV *env;
   QO_INDEX_ENTRY *index_entryp;
@@ -8834,7 +8882,7 @@ qo_generate_join_index_scan (QO_INFO * infop, JOIN_TYPE join_type, QO_PLAN * out
 		      if (QO_TERM_IS_FLAGED (termp, QO_TERM_EQUAL_OP))
 			{
 			  bitset_add (&range_terms, t);
-			  bitset_add (&(index_entryp->multi_col_range_segs), seg);
+			  bitset_add (& (index_entryp->multi_col_range_segs), seg);
 			  n++;
 			}
 		    }
@@ -8910,13 +8958,13 @@ qo_generate_join_index_scan (QO_INFO * infop, JOIN_TYPE join_type, QO_PLAN * out
 	{
 	  /* now, key-filter is assigned; exclude key-range, key-filter terms from remaining terms */
 	  bitset_difference (&remaining_terms, &range_terms);
-	  bitset_difference (&remaining_terms, &(inner_plan->plan_un.scan.kf_terms));
+	  bitset_difference (&remaining_terms, & (inner_plan->plan_un.scan.kf_terms));
 
 	  n =
-	    qo_check_plan_on_info (infop,
-				   qo_join_new (infop, join_type, QO_JOINMETHOD_IDX_JOIN, outer_plan, inner_plan,
-						&empty_terms, &empty_terms, afj_terms, &remaining_terms,
-						pinned_subqueries, &empty_terms));
+		  qo_check_plan_on_info (infop,
+					 qo_join_new (infop, join_type, QO_JOINMETHOD_IDX_JOIN, outer_plan, inner_plan,
+					     &empty_terms, &empty_terms, afj_terms, &remaining_terms,
+					     pinned_subqueries, &empty_terms));
 	}
     }
 
@@ -8933,7 +8981,7 @@ qo_generate_join_index_scan (QO_INFO * infop, JOIN_TYPE join_type, QO_PLAN * out
  *   plan(in):
  */
 bool
-qo_is_seq_scan (QO_PLAN * plan)
+qo_is_seq_scan (QO_PLAN *plan)
 {
   if (plan && plan->plan_type == QO_PLANTYPE_SCAN && plan->plan_un.scan.scan_method == QO_SCANMETHOD_SEQ_SCAN)
     {
@@ -8954,7 +9002,7 @@ qo_is_seq_scan (QO_PLAN * plan)
  *   sequential scan plan may be skipped for a hinted node (CBRD-26906).
  */
 static bool
-qo_node_using_index_forced (QO_NODE * nodep)
+qo_node_using_index_forced (QO_NODE *nodep)
 {
   QO_USING_INDEX *uip;
   int j;
@@ -8985,7 +9033,7 @@ qo_node_using_index_forced (QO_NODE * nodep)
  *   nodep(in): pointer to QO_NODE (node in the join graph)
  */
 static void
-qo_generate_seq_scan (QO_INFO * infop, QO_NODE * nodep)
+qo_generate_seq_scan (QO_INFO *infop, QO_NODE *nodep)
 {
   int n;
   QO_PLAN *planp;
@@ -9006,7 +9054,7 @@ qo_generate_seq_scan (QO_INFO * infop, QO_NODE * nodep)
  *   plan(in):
  */
 bool
-qo_is_iscan (QO_PLAN * plan)
+qo_is_iscan (QO_PLAN *plan)
 {
   if (plan && plan->plan_type == QO_PLANTYPE_SCAN
       && (plan->plan_un.scan.scan_method == QO_SCANMETHOD_INDEX_SCAN
@@ -9027,7 +9075,7 @@ qo_is_iscan (QO_PLAN * plan)
  *   nsegs(in):
  */
 static int
-qo_generate_index_scan (QO_INFO * infop, QO_NODE * nodep, QO_NODE_INDEX_ENTRY * ni_entryp, int nsegs)
+qo_generate_index_scan (QO_INFO *infop, QO_NODE *nodep, QO_NODE_INDEX_ENTRY *ni_entryp, int nsegs)
 {
   QO_INDEX_ENTRY *index_entryp;
   BITSET_ITERATOR iter;
@@ -9057,32 +9105,32 @@ qo_generate_index_scan (QO_INFO * infop, QO_NODE * nodep, QO_NODE_INDEX_ENTRY * 
     {
       assert (nsegs == 1);
       assert (index_entryp->is_iss_candidate == 0);
-      assert (!(index_entryp->ils_prefix_len > 0));
+      assert (! (index_entryp->ils_prefix_len > 0));
     }
 
   start_column = index_entryp->is_iss_candidate ? 1 : 0;
 
   for (i = start_column; i < nsegs - 1; i++)
     {
-      t = bitset_first_member (&(index_entryp->seg_equal_terms[i]));
+      t = bitset_first_member (& (index_entryp->seg_equal_terms[i]));
       bitset_add (&range_terms, t);
 
       /* add multi_col_range_segs */
       if (QO_TERM_IS_FLAGED (QO_ENV_TERM (infop->env, t), QO_TERM_MULTI_COLL_PRED))
 	{
-	  bitset_add (&(index_entryp->multi_col_range_segs), index_entryp->seg_idxs[i]);
+	  bitset_add (& (index_entryp->multi_col_range_segs), index_entryp->seg_idxs[i]);
 	}
     }
 
   /* for each terms associated with the last segment */
-  t = bitset_iterate (&(index_entryp->seg_equal_terms[nsegs - 1]), &iter);
+  t = bitset_iterate (& (index_entryp->seg_equal_terms[nsegs - 1]), &iter);
   for (; t != -1; t = bitset_next_member (&iter))
     {
       bitset_add (&range_terms, t);
       /* add multi_col_range_segs */
       if (QO_TERM_IS_FLAGED (QO_ENV_TERM (infop->env, t), QO_TERM_MULTI_COLL_PRED))
 	{
-	  bitset_add (&(index_entryp->multi_col_range_segs), index_entryp->seg_idxs[nsegs - 1]);
+	  bitset_add (& (index_entryp->multi_col_range_segs), index_entryp->seg_idxs[nsegs - 1]);
 	}
 
       /* generate index scan plan */
@@ -9098,11 +9146,11 @@ qo_generate_index_scan (QO_INFO * infop, QO_NODE * nodep, QO_NODE_INDEX_ENTRY * 
       bitset_remove (&range_terms, t);
       if (QO_TERM_IS_FLAGED (QO_ENV_TERM (infop->env, t), QO_TERM_MULTI_COLL_PRED))
 	{
-	  bitset_remove (&(index_entryp->multi_col_range_segs), index_entryp->seg_idxs[nsegs - 1]);
+	  bitset_remove (& (index_entryp->multi_col_range_segs), index_entryp->seg_idxs[nsegs - 1]);
 	}
     }
 
-  bitset_assign (&seg_other_terms, &(index_entryp->seg_other_terms[nsegs - 1]));
+  bitset_assign (&seg_other_terms, & (index_entryp->seg_other_terms[nsegs - 1]));
   for (t = bitset_iterate (&seg_other_terms, &iter); t != -1; t = bitset_next_member (&iter))
     {
       bitset_add (&range_terms, t);
@@ -9134,7 +9182,7 @@ qo_generate_index_scan (QO_INFO * infop, QO_NODE * nodep, QO_NODE_INDEX_ENTRY * 
  *   ni_entryp(in): pointer to QO_NODE_INDEX_ENTRY (node index entry)
  */
 static int
-qo_generate_loose_index_scan (QO_INFO * infop, QO_NODE * nodep, QO_NODE_INDEX_ENTRY * ni_entryp)
+qo_generate_loose_index_scan (QO_INFO *infop, QO_NODE *nodep, QO_NODE_INDEX_ENTRY *ni_entryp)
 {
   QO_INDEX_ENTRY *index_entryp;
   int n = 0;
@@ -9151,7 +9199,7 @@ qo_generate_loose_index_scan (QO_INFO * infop, QO_NODE * nodep, QO_NODE_INDEX_EN
       return 0;
     }
 
-  assert (bitset_is_empty (&(index_entryp->seg_equal_terms[0])));
+  assert (bitset_is_empty (& (index_entryp->seg_equal_terms[0])));
   assert (index_entryp->ils_prefix_len > 0);
   assert (QO_ENTRY_MULTI_COL (index_entryp));
   assert (index_entryp->cover_segments == true);
@@ -9176,7 +9224,7 @@ qo_generate_loose_index_scan (QO_INFO * infop, QO_NODE * nodep, QO_NODE_INDEX_EN
  * subplan (in) : subplan over which to generate the SORT_LIMIT plan
  */
 static int
-qo_generate_sort_limit_plan (QO_ENV * env, QO_INFO * infop, QO_PLAN * subplan)
+qo_generate_sort_limit_plan (QO_ENV *env, QO_INFO *infop, QO_PLAN *subplan)
 {
   int n;
   QO_PLAN *plan;
@@ -9205,7 +9253,7 @@ qo_generate_sort_limit_plan (QO_ENV * env, QO_INFO * infop, QO_PLAN * subplan)
  *   node(in): pointer to QO_NODE
  */
 static int
-qo_has_is_not_null_term (QO_NODE * node)
+qo_has_is_not_null_term (QO_NODE *node)
 {
   QO_ENV *env;
   QO_TERM *term;
@@ -9225,7 +9273,7 @@ qo_has_is_not_null_term (QO_NODE * node)
       term = QO_ENV_TERM (env, i);
 
       /* term should belong to the given node */
-      if (!bitset_intersects (&(QO_TERM_SEGS (term)), &(QO_NODE_SEGS (node))))
+      if (!bitset_intersects (& (QO_TERM_SEGS (term)), & (QO_NODE_SEGS (node))))
 	{
 	  continue;
 	}
@@ -9267,7 +9315,7 @@ qo_has_is_not_null_term (QO_NODE * node)
  *   planner(in):
  */
 static QO_PLAN *
-qo_search_planner (QO_PLANNER * planner)
+qo_search_planner (QO_PLANNER *planner)
 {
   int i, j, nsegs;
   bool broken;
@@ -9314,8 +9362,8 @@ qo_search_planner (QO_PLANNER * planner)
   if (planner->N > 1)
     {
       planner->M =
-	QO_PARTITION_M_OFFSET (&planner->partition[planner->P - 1]) +
-	QO_JOIN_INFO_SIZE (&planner->partition[planner->P - 1]);
+	      QO_PARTITION_M_OFFSET (&planner->partition[planner->P - 1]) +
+	      QO_JOIN_INFO_SIZE (&planner->partition[planner->P - 1]);
 
       join_info_bytes = planner->M * sizeof (QO_INFO *);
       if (join_info_bytes > 0)
@@ -9337,7 +9385,7 @@ qo_search_planner (QO_PLANNER * planner)
       memset (planner->join_info, 0, join_info_bytes);
     }
 
-  bitset_assign (&remaining_subqueries, &(planner->all_subqueries));
+  bitset_assign (&remaining_subqueries, & (planner->all_subqueries));
 
   /*
    * Add appropriate scan plans for each node.
@@ -9362,8 +9410,8 @@ qo_search_planner (QO_PLANNER * planner)
       BITSET_CLEAR (nodes);
       bitset_add (&nodes, i);
       planner->node_info[i] =
-	qo_alloc_info (planner, &nodes, &QO_NODE_SARGS (node), &QO_NODE_EQCLASSES (node),
-		       QO_NODE_SELECTIVITY (node) * (double) QO_NODE_NCARD (node), (double) QO_NODE_NCARD (node));
+	      qo_alloc_info (planner, &nodes, &QO_NODE_SARGS (node), &QO_NODE_EQCLASSES (node),
+			     QO_NODE_SELECTIVITY (node) * (double) QO_NODE_NCARD (node), (double) QO_NODE_NCARD (node));
 
       if (planner->node_info[i] == NULL)
 	{
@@ -9376,14 +9424,14 @@ qo_search_planner (QO_PLANNER * planner)
 	{
 	  subq = &planner->subqueries[subq_idx];
 	  if (bitset_is_empty (&subq->nodes)	/* uncorrelated */
-	      || (bitset_subset (&nodes, &(subq->nodes))	/* correlated */
-		  && bitset_subset (&(QO_NODE_SARGS (node)), &(subq->terms))))
+	      || (bitset_subset (&nodes, & (subq->nodes))	/* correlated */
+		  && bitset_subset (& (QO_NODE_SARGS (node)), & (subq->terms))))
 	    {
 	      bitset_add (&subqueries, subq_idx);
 	      bitset_remove (&remaining_subqueries, subq_idx);
 	    }
 	}
-      bitset_assign (&(QO_NODE_SUBQUERIES (node)), &subqueries);
+      bitset_assign (& (QO_NODE_SUBQUERIES (node)), &subqueries);
     }
 
   /*
@@ -9407,9 +9455,9 @@ qo_search_planner (QO_PLANNER * planner)
 	  assert (node_index != NULL && QO_NI_N (node_index) == 1);
 	  ni_entry = QO_NI_ENTRY (node_index, 0);
 	  n =
-	    qo_check_plan_on_info (info,
-				   qo_index_scan_new (info, node, ni_entry, QO_SCANMETHOD_INDEX_SCAN_INSPECT, NULL,
-						      NULL));
+		  qo_check_plan_on_info (info,
+					 qo_index_scan_new (info, node, ni_entry, QO_SCANMETHOD_INDEX_SCAN_INSPECT, NULL,
+					     NULL));
 	  assert (n == 1);
 	  continue;
 	}
@@ -9446,12 +9494,12 @@ qo_search_planner (QO_PLANNER * planner)
 	      BITSET_CLEAR (seg_terms);
 	      for (nsegs = start_column; nsegs < index_entry->nsegs; nsegs++)
 		{
-		  bitset_union (&seg_terms, &(index_entry->seg_equal_terms[nsegs]));
-		  bitset_union (&seg_terms, &(index_entry->seg_other_terms[nsegs]));
+		  bitset_union (&seg_terms, & (index_entry->seg_equal_terms[nsegs]));
+		  bitset_union (&seg_terms, & (index_entry->seg_other_terms[nsegs]));
 
-		  if (bitset_is_empty (&(index_entry->seg_equal_terms[nsegs])))
+		  if (bitset_is_empty (& (index_entry->seg_equal_terms[nsegs])))
 		    {
-		      if (!bitset_is_empty (&(index_entry->seg_other_terms[nsegs])))
+		      if (!bitset_is_empty (& (index_entry->seg_other_terms[nsegs])))
 			{
 			  nsegs++;	/* include this term */
 			}
@@ -9459,7 +9507,7 @@ qo_search_planner (QO_PLANNER * planner)
 		    }
 		}
 
-	      bitset_intersect (&seg_terms, &(QO_NODE_SARGS (node)));
+	      bitset_intersect (&seg_terms, & (QO_NODE_SARGS (node)));
 
 	      n = 0;		/* init */
 
@@ -9481,9 +9529,9 @@ qo_search_planner (QO_PLANNER * planner)
 		   */
 
 		  n =
-		    qo_check_plan_on_info (info,
-					   qo_index_scan_new (info, node, ni_entry, QO_SCANMETHOD_INDEX_SCAN,
-							      &seg_terms, NULL));
+			  qo_check_plan_on_info (info,
+						 qo_index_scan_new (info, node, ni_entry, QO_SCANMETHOD_INDEX_SCAN,
+						     &seg_terms, NULL));
 		  normal_index_plan_n += n;
 		}
 	      else if (index_entry->ils_prefix_len > 0)
@@ -9520,18 +9568,18 @@ qo_search_planner (QO_PLANNER * planner)
 		      && qo_validate_index_for_groupby (info->env, ni_entry))
 		    {
 		      n =
-			qo_check_plan_on_info (info,
-					       qo_index_scan_new (info, node, ni_entry,
-								  QO_SCANMETHOD_INDEX_GROUPBY_SCAN, &seg_terms, NULL));
+			      qo_check_plan_on_info (info,
+						     qo_index_scan_new (info, node, ni_entry,
+							 QO_SCANMETHOD_INDEX_GROUPBY_SCAN, &seg_terms, NULL));
 		    }
 
 		  if (!n && !index_entry->orderby_skip && !tree->info.query.q.select.group_by
 		      && tree->info.query.order_by && qo_validate_index_for_orderby (info->env, ni_entry))
 		    {
 		      n =
-			qo_check_plan_on_info (info,
-					       qo_index_scan_new (info, node, ni_entry,
-								  QO_SCANMETHOD_INDEX_ORDERBY_SCAN, &seg_terms, NULL));
+			      qo_check_plan_on_info (info,
+						     qo_index_scan_new (info, node, ni_entry,
+							 QO_SCANMETHOD_INDEX_ORDERBY_SCAN, &seg_terms, NULL));
 		    }
 
 		  /* CBRD-26906: an interesting-order (group-by / order-by skip) index
@@ -9689,7 +9737,7 @@ end:
  *   planner(in):
  */
 static void
-qo_clean_planner (QO_PLANNER * planner)
+qo_clean_planner (QO_PLANNER *planner)
 {
   /*
    * This cleans up everything that isn't needed for the surviving
@@ -9699,8 +9747,8 @@ qo_clean_planner (QO_PLANNER * planner)
    * worry about them here.
    */
   planner->cleanup_needed = false;
-  bitset_delset (&(planner->all_subqueries));
-  bitset_delset (&(planner->final_segs));
+  bitset_delset (& (planner->all_subqueries));
+  bitset_delset (& (planner->final_segs));
   qo_plans_teardown (planner->env);
 }
 
@@ -9723,7 +9771,7 @@ qo_clean_planner (QO_PLANNER * planner)
  *   remaining_subqueries(in):
  */
 static QO_INFO *
-qo_search_partition_join (QO_PLANNER * planner, QO_PARTITION * partition, BITSET * remaining_subqueries)
+qo_search_partition_join (QO_PLANNER *planner, QO_PARTITION *partition, BITSET *remaining_subqueries)
 {
   QO_ENV *env;
   int i, nodes_cnt, node_idx;
@@ -9749,7 +9797,7 @@ qo_search_partition_join (QO_PLANNER * planner, QO_PARTITION * partition, BITSET
   bitset_init (&remaining_terms, env);
 
   /* include useful nodes */
-  bitset_assign (&remaining_nodes, &(QO_PARTITION_NODES (partition)));
+  bitset_assign (&remaining_nodes, & (QO_PARTITION_NODES (partition)));
   nodes_cnt = bitset_cardinality (&remaining_nodes);
 
   num_path_inner = 0;		/* init */
@@ -9763,7 +9811,7 @@ qo_search_partition_join (QO_PLANNER * planner, QO_PARTITION * partition, BITSET
 	  continue;		/* skip and go ahead */
 	}
 
-      if (bitset_subset (&remaining_nodes, &(QO_TERM_NODES (term))))
+      if (bitset_subset (&remaining_nodes, & (QO_TERM_NODES (term))))
 	{
 	  bitset_add (&remaining_terms, i);
 	  if (QO_TERM_CLASS (term) == QO_TC_PATH)
@@ -9803,7 +9851,8 @@ qo_search_partition_join (QO_PLANNER * planner, QO_PARTITION * partition, BITSET
 				/* partial join search */
 				: NULL /* total join search */ );
       if (planner->best_info)
-	{			/* OK */
+	{
+	  /* OK */
 	  break;		/* found best total join plan */
 	}
 
@@ -9855,12 +9904,13 @@ qo_search_partition_join (QO_PLANNER * planner, QO_PARTITION * partition, BITSET
 	}
 
       if (visited_info == NULL)
-	{			/* something wrong */
+	{
+	  /* something wrong */
 	  break;		/* give up */
 	}
 
-      bitset_assign (&visited_terms, &(visited_info->terms));
-      bitset_difference (&remaining_terms, &(visited_info->terms));
+      bitset_assign (&visited_terms, & (visited_info->terms));
+      bitset_difference (&remaining_terms, & (visited_info->terms));
 
       planner->join_unit++;	/* increase join unit level */
 
@@ -9885,11 +9935,11 @@ qo_search_partition_join (QO_PLANNER * planner, QO_PARTITION * partition, BITSET
  *   remaining_subqueries(in):
  */
 static QO_PLAN *
-qo_search_partition (QO_PLANNER * planner, QO_PARTITION * partition, QO_EQCLASS * order, BITSET * remaining_subqueries)
+qo_search_partition (QO_PLANNER *planner, QO_PARTITION *partition, QO_EQCLASS *order, BITSET *remaining_subqueries)
 {
   int i, nodes_cnt;
 
-  nodes_cnt = bitset_cardinality (&(QO_PARTITION_NODES (partition)));
+  nodes_cnt = bitset_cardinality (& (QO_PARTITION_NODES (partition)));
 
   /* nodes are multi if there is a join to be done. If not, this is just a degenerate search to determine which of the
    * indexes (if available) to use for the (single) class involved in the query.
@@ -9902,7 +9952,7 @@ qo_search_partition (QO_PLANNER * planner, QO_PARTITION * partition, QO_EQCLASS 
     {
       QO_NODE *node;
 
-      i = bitset_first_member (&(QO_PARTITION_NODES (partition)));
+      i = bitset_first_member (& (QO_PARTITION_NODES (partition)));
       node = QO_ENV_NODE (planner->env, i);
       planner->best_info = planner->node_info[QO_NODE_IDX (node)];
     }
@@ -9931,14 +9981,15 @@ qo_search_partition (QO_PLANNER * planner, QO_PARTITION * partition, QO_EQCLASS 
 
       for (info = planner->info_list; info; info = info->next)
 	{
-	  if (bitset_subset (&(QO_PARTITION_NODES (partition)), &(info->nodes)))
+	  if (bitset_subset (& (QO_PARTITION_NODES (partition)), & (info->nodes)))
 	    {
 	      qo_detach_info (info);
 	    }
 	}
     }
   else
-    {				/* single class */
+    {
+      /* single class */
       for (i = 0; i < (signed) planner->N; i++)
 	{
 	  if (BITSET_MEMBER (QO_PARTITION_NODES (partition), i))
@@ -9957,7 +10008,7 @@ qo_search_partition (QO_PLANNER * planner, QO_PARTITION * partition, QO_EQCLASS 
  *   planner(in):
  */
 static void
-sort_partitions (QO_PLANNER * planner)
+sort_partitions (QO_PLANNER *planner)
 {
   int i, j;
   QO_PARTITION *i_part, *j_part;
@@ -9973,7 +10024,7 @@ sort_partitions (QO_PLANNER * planner)
 	   * If the higher partition (i_part) supplies something that
 	   * the lower partition (j_part) needs, swap them.
 	   */
-	  if (bitset_intersects (&(QO_PARTITION_NODES (i_part)), &(QO_PARTITION_DEPENDENCIES (j_part))))
+	  if (bitset_intersects (& (QO_PARTITION_NODES (i_part)), & (QO_PARTITION_DEPENDENCIES (j_part))))
 	    {
 	      tmp = *i_part;
 	      *i_part = *j_part;
@@ -9990,7 +10041,7 @@ sort_partitions (QO_PLANNER * planner)
  *   reamining_subqueries(in):
  */
 static QO_PLAN *
-qo_combine_partitions (QO_PLANNER * planner, BITSET * reamining_subqueries)
+qo_combine_partitions (QO_PLANNER *planner, BITSET *reamining_subqueries)
 {
   QO_PARTITION *partition = planner->partition;
   QO_PLAN *plan, *t_plan;
@@ -10031,17 +10082,17 @@ qo_combine_partitions (QO_PLANNER * planner, BITSET * reamining_subqueries)
   cardinality = (plan->info)->cardinality;
   total_rows = (plan->info)->total_rows;
 
-  bitset_assign (&nodes, &((plan->info)->nodes));
-  bitset_assign (&terms, &((plan->info)->terms));
-  bitset_assign (&eqclasses, &((plan->info)->eqclasses));
+  bitset_assign (&nodes, & ((plan->info)->nodes));
+  bitset_assign (&terms, & ((plan->info)->terms));
+  bitset_assign (&eqclasses, & ((plan->info)->eqclasses));
 
   for (++partition, i = 1; i < (signed) planner->P; ++partition, ++i)
     {
       next_plan = QO_PARTITION_PLAN (partition);
 
-      bitset_union (&nodes, &((next_plan->info)->nodes));
-      bitset_union (&terms, &((next_plan->info)->terms));
-      bitset_union (&eqclasses, &((next_plan->info)->eqclasses));
+      bitset_union (&nodes, & ((next_plan->info)->nodes));
+      bitset_union (&terms, & ((next_plan->info)->terms));
+      bitset_union (&eqclasses, & ((next_plan->info)->eqclasses));
       cardinality *= (next_plan->info)->cardinality;
       total_rows *= (next_plan->info)->total_rows;
 
@@ -10049,8 +10100,8 @@ qo_combine_partitions (QO_PLANNER * planner, BITSET * reamining_subqueries)
 
       for (t = planner->E; t < (signed) planner->T; ++t)
 	{
-	  if (!bitset_is_empty (&(QO_TERM_NODES (&planner->term[t]))) && !BITSET_MEMBER (terms, t)
-	      && bitset_subset (&nodes, &(QO_TERM_NODES (&planner->term[t])))
+	  if (!bitset_is_empty (& (QO_TERM_NODES (&planner->term[t]))) && !BITSET_MEMBER (terms, t)
+	      && bitset_subset (&nodes, & (QO_TERM_NODES (&planner->term[t])))
 	      && (QO_TERM_CLASS (&planner->term[t]) != QO_TC_TOTALLY_AFTER_JOIN))
 	    {
 	      bitset_add (&sarged_terms, t);
@@ -10061,7 +10112,7 @@ qo_combine_partitions (QO_PLANNER * planner, BITSET * reamining_subqueries)
       for (s = bitset_iterate (reamining_subqueries, &bi); s != -1; s = bitset_next_member (&bi))
 	{
 	  QO_SUBQUERY *subq = &planner->subqueries[s];
-	  if (bitset_subset (&nodes, &(subq->nodes)) && bitset_subset (&sarged_terms, &(subq->terms)))
+	  if (bitset_subset (&nodes, & (subq->nodes)) && bitset_subset (&sarged_terms, & (subq->terms)))
 	    {
 	      bitset_add (&subqueries, s);
 	      bitset_remove (reamining_subqueries, s);
@@ -10083,7 +10134,7 @@ qo_combine_partitions (QO_PLANNER * planner, BITSET * reamining_subqueries)
 
   for (i = planner->E; i < (signed) planner->T; ++i)
     {
-      if (bitset_is_empty (&(QO_TERM_NODES (&planner->term[i]))))
+      if (bitset_is_empty (& (QO_TERM_NODES (&planner->term[i]))))
 	{
 	  bitset_add (&sarged_terms, i);
 	}
@@ -10092,7 +10143,7 @@ qo_combine_partitions (QO_PLANNER * planner, BITSET * reamining_subqueries)
   /* skip empty sort plan */
   for (t_plan = plan; t_plan && t_plan->plan_type == QO_PLANTYPE_SORT; t_plan = t_plan->plan_un.sort.subplan)
     {
-      if (!bitset_is_empty (&(t_plan->sarged_terms)))
+      if (!bitset_is_empty (& (t_plan->sarged_terms)))
 	{
 	  break;
 	}
@@ -10100,7 +10151,7 @@ qo_combine_partitions (QO_PLANNER * planner, BITSET * reamining_subqueries)
 
   if (t_plan)
     {
-      bitset_union (&(t_plan->sarged_terms), &sarged_terms);
+      bitset_union (& (t_plan->sarged_terms), &sarged_terms);
     }
   else if (plan != NULL)
     {
@@ -10125,7 +10176,7 @@ qo_combine_partitions (QO_PLANNER * planner, BITSET * reamining_subqueries)
  *   attr(in): pt node for the attribute for which we want the index cardinality
  */
 int
-qo_index_cardinality (QO_ENV * env, PT_NODE * attr)
+qo_index_cardinality (QO_ENV *env, PT_NODE *attr)
 {
   PT_NODE *dummy;
   QO_NODE *nodep;
@@ -10192,7 +10243,7 @@ qo_index_cardinality (QO_ENV * env, PT_NODE * attr)
  * only column of a normal unique-family index; otherwise 0.
  */
 static int
-qo_unique_index_cardinality (QO_ENV * env, PT_NODE * attr)
+qo_unique_index_cardinality (QO_ENV *env, PT_NODE *attr)
 {
   PT_NODE *dummy;
   QO_NODE *nodep;
@@ -10265,7 +10316,7 @@ qo_unique_index_cardinality (QO_ENV * env, PT_NODE * attr)
  *   seg_bitset(in): segment bitset for checking if there are duplicate columns
  */
 static int
-qo_index_cardinality_with_dedup (QO_ENV * env, PT_NODE * attr, BITSET * seg_bitset)
+qo_index_cardinality_with_dedup (QO_ENV *env, PT_NODE *attr, BITSET *seg_bitset)
 {
   PT_NODE *dummy;
   QO_NODE *nodep;
@@ -10349,7 +10400,7 @@ qo_index_cardinality_with_dedup (QO_ENV * env, PT_NODE * attr, BITSET * seg_bits
  * plan (in) : plan to verify
  */
 bool
-qo_is_all_unique_index_columns_are_equi_terms (QO_PLAN * plan)
+qo_is_all_unique_index_columns_are_equi_terms (QO_PLAN *plan)
 {
   if (qo_is_iscan (plan) && plan->plan_un.scan.index && plan->plan_un.scan.index->head
       && (plan->plan_un.scan.index->head->all_unique_index_columns_are_equi_terms))
@@ -10365,7 +10416,7 @@ qo_is_all_unique_index_columns_are_equi_terms (QO_PLAN * plan)
  *   plan(in):
  */
 bool
-qo_is_iscan_from_orderby (QO_PLAN * plan)
+qo_is_iscan_from_orderby (QO_PLAN *plan)
 {
   if (plan && plan->plan_type == QO_PLANTYPE_SCAN && plan->plan_un.scan.scan_method == QO_SCANMETHOD_INDEX_ORDERBY_SCAN)
     {
@@ -10380,7 +10431,7 @@ qo_is_iscan_from_orderby (QO_PLAN * plan)
  *   return: true/false
  */
 static bool
-qo_validate_index_term_notnull (QO_ENV * env, QO_INDEX_ENTRY * index_entryp)
+qo_validate_index_term_notnull (QO_ENV *env, QO_INDEX_ENTRY *index_entryp)
 {
   bool term_notnull = false;	/* init */
   PT_NODE *node;
@@ -10452,7 +10503,7 @@ qo_validate_index_term_notnull (QO_ENV * env, QO_INDEX_ENTRY * index_entryp)
  *   return: true/false
  */
 static bool
-qo_validate_index_attr_notnull (QO_ENV * env, QO_INDEX_ENTRY * index_entryp, PT_NODE * col)
+qo_validate_index_attr_notnull (QO_ENV *env, QO_INDEX_ENTRY *index_entryp, PT_NODE *col)
 {
   bool attr_notnull = false;	/* init */
   QO_NODE *node;
@@ -10487,7 +10538,8 @@ qo_validate_index_attr_notnull (QO_ENV * env, QO_INDEX_ENTRY * index_entryp, PT_
 
   segp = lookup_seg (node, col, env);
   if (segp == NULL)
-    {				/* is invalid case */
+    {
+      /* is invalid case */
       assert (false);
       return false;
     }
@@ -10615,7 +10667,7 @@ qo_validate_index_attr_notnull (QO_ENV * env, QO_INDEX_ENTRY * index_entryp, PT_
  *  return: 1 if the index can be used, 0 elseware
  */
 static int
-qo_validate_index_for_orderby (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entryp)
+qo_validate_index_for_orderby (QO_ENV *env, QO_NODE_INDEX_ENTRY *ni_entryp)
 {
   bool key_notnull = false;	/* init */
   QO_INDEX_ENTRY *index_entryp;
@@ -10702,7 +10754,7 @@ end:
  *	  qo_validate_index_for_groupby, qo_validate_index_for_orderby
  */
 static PT_NODE *
-qo_search_isnull_key_expr (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk)
+qo_search_isnull_key_expr (PARSER_CONTEXT *parser, PT_NODE *tree, void *arg, int *continue_walk)
 {
   BITSET expr_segments, key_segment;
   QO_ENV *env;
@@ -10760,7 +10812,7 @@ qo_search_isnull_key_expr (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, i
  * Note: get product of NDV of each column on GROUP BY
  */
 static PT_NODE *
-qo_get_col_product_ndv (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int *continue_walk)
+qo_get_col_product_ndv (PARSER_CONTEXT *parser, PT_NODE *tree, void *arg, int *continue_walk)
 {
   NDV_INFO *ndv_info = (NDV_INFO *) arg;
   int ndv;
@@ -10782,7 +10834,7 @@ qo_get_col_product_ndv (PARSER_CONTEXT * parser, PT_NODE * tree, void *arg, int 
 }
 
 static double
-qo_get_term_cost_weight (QO_TERM * term)
+qo_get_term_cost_weight (QO_TERM *term)
 {
   PT_NODE *expr;
   PT_NODE *node;
@@ -10812,74 +10864,74 @@ qo_get_term_cost_weight (QO_TERM * term)
 	{
 	case PT_EQ:
 	case PT_NE:
-	  {
-	    PT_NODE *lhs = node->info.expr.arg1;
+	{
+	  PT_NODE *lhs = node->info.expr.arg1;
 
-	    if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
-	      {
-		weight = QO_COST_WEIGHT_STRING_EQUAL;
-	      }
-	    else
-	      {
-		weight = QO_COST_WEIGHT_NUMERIC_COMPARE;
-	      }
-	    break;
-	  }
+	  if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	    {
+	      weight = QO_COST_WEIGHT_STRING_EQUAL;
+	    }
+	  else
+	    {
+	      weight = QO_COST_WEIGHT_NUMERIC_COMPARE;
+	    }
+	  break;
+	}
 
 	case PT_LT:
 	case PT_LE:
 	case PT_GT:
 	case PT_GE:
-	  {
-	    PT_NODE *lhs = node->info.expr.arg1;
-	    if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
-	      {
-		weight = QO_COST_WEIGHT_STRING_RANGE;
-	      }
-	    else
-	      {
-		weight = QO_COST_WEIGHT_NUMERIC_COMPARE;
-	      }
-	    break;
-	  }
+	{
+	  PT_NODE *lhs = node->info.expr.arg1;
+	  if (lhs != NULL && (lhs->type_enum == PT_TYPE_CHAR || lhs->type_enum == PT_TYPE_VARCHAR))
+	    {
+	      weight = QO_COST_WEIGHT_STRING_RANGE;
+	    }
+	  else
+	    {
+	      weight = QO_COST_WEIGHT_NUMERIC_COMPARE;
+	    }
+	  break;
+	}
 
 	case PT_LIKE:
 	case PT_NOT_LIKE:
-	  {
-	    PT_NODE *rhs = node->info.expr.arg2;
+	{
+	  PT_NODE *rhs = node->info.expr.arg2;
 
-	    if (rhs != NULL && rhs->node_type == PT_VALUE)
-	      {
-		const char *pat = db_get_string (&rhs->info.value.db_value);
-		if (pat != NULL)
-		  {
-		    const char *pct = strchr (pat, '%');
-		    const char *und = strchr (pat, '_');
+	  if (rhs != NULL && rhs->node_type == PT_VALUE)
+	    {
+	      const char *pat = db_get_string (&rhs->info.value.db_value);
+	      if (pat != NULL)
+		{
+		  const char *pct = strchr (pat, '%');
+		  const char *und = strchr (pat, '_');
 
-		    if (pct != NULL && pct[1] == '\0' && und == NULL && pct != pat)
-		      {
-			weight = QO_COST_WEIGHT_LIKE_PREFIX;
-		      }
-		    else if (pat[0] == '%' || und != NULL)
-		      {
-			weight = QO_COST_WEIGHT_LIKE_CONTAINS;
-		      }
-		    else
-		      {
-			weight = QO_COST_WEIGHT_LIKE_COMPLEX;
-		      }
-		  }
-		else
-		  {
-		    weight = QO_COST_WEIGHT_LIKE_COMPLEX;
-		  }
-	      }
-	    else
-	      {
-		weight = QO_COST_WEIGHT_LIKE_COMPLEX;
-	      }
-	    break;
-	  }
+		  if (pct != NULL && pct[1] == '\0' && und == NULL && pct != pat)
+		    {
+		      weight = QO_COST_WEIGHT_LIKE_PREFIX;
+		    }
+		  else if (pat[0] == '%' || und != NULL)
+		    {
+		      weight = QO_COST_WEIGHT_LIKE_CONTAINS;
+		    }
+		  else
+		    {
+		      weight = QO_COST_WEIGHT_LIKE_COMPLEX;
+		    }
+		}
+	      else
+		{
+		  weight = QO_COST_WEIGHT_LIKE_COMPLEX;
+		}
+	    }
+	  else
+	    {
+	      weight = QO_COST_WEIGHT_LIKE_COMPLEX;
+	    }
+	  break;
+	}
 
 	case PT_LIKE_ESCAPE:
 	  weight = QO_COST_WEIGHT_LIKE_COMPLEX;
@@ -10908,7 +10960,7 @@ qo_get_term_cost_weight (QO_TERM * term)
  *   b(in):
  */
 static QO_PLAN_COMPARE_RESULT
-qo_plan_iscan_terms_cmp (QO_PLAN * a, QO_PLAN * b)
+qo_plan_iscan_terms_cmp (QO_PLAN *a, QO_PLAN *b)
 {
   QO_NODE_INDEX_ENTRY *a_ni, *b_ni;
   QO_INDEX_ENTRY *a_ent, *b_ent;
@@ -10932,41 +10984,41 @@ qo_plan_iscan_terms_cmp (QO_PLAN * a, QO_PLAN * b)
   /* index entry of spec 'a' */
   a_ni = a->plan_un.scan.index;
   a_ent = (a_ni)->head;
-  a_cum = &(a_ni)->cum_stats;
+  a_cum = & (a_ni)->cum_stats;
   assert (a_cum != NULL);
 
   /* index range terms */
-  a_range = bitset_cardinality (&(a->plan_un.scan.terms));
-  if (a_range > 0 && !(a->plan_un.scan.index_equi))
+  a_range = bitset_cardinality (& (a->plan_un.scan.terms));
+  if (a_range > 0 && ! (a->plan_un.scan.index_equi))
     {
       a_range--;		/* set the last equal range term */
     }
 
   /* index filter terms */
-  a_filter = bitset_cardinality (&(a->plan_un.scan.kf_terms));
+  a_filter = bitset_cardinality (& (a->plan_un.scan.kf_terms));
 
   /* index entry of spec 'b' */
   b_ni = b->plan_un.scan.index;
   b_ent = (b_ni)->head;
-  b_cum = &(b_ni)->cum_stats;
+  b_cum = & (b_ni)->cum_stats;
   assert (b_cum != NULL);
 
   /* index range terms */
-  b_range = bitset_cardinality (&(b->plan_un.scan.terms));
-  if (b_range > 0 && !(b->plan_un.scan.index_equi))
+  b_range = bitset_cardinality (& (b->plan_un.scan.terms));
+  if (b_range > 0 && ! (b->plan_un.scan.index_equi))
     {
       b_range--;		/* set the last equal range term */
     }
 
   /* index filter terms */
-  b_filter = bitset_cardinality (&(b->plan_un.scan.kf_terms));
+  b_filter = bitset_cardinality (& (b->plan_un.scan.kf_terms));
 
   assert (a_range >= 0);
   assert (b_range >= 0);
 
   /* STEP 1: check by terms containment */
 
-  if (bitset_is_equivalent (&(a->plan_un.scan.terms), &(b->plan_un.scan.terms)))
+  if (bitset_is_equivalent (& (a->plan_un.scan.terms), & (b->plan_un.scan.terms)))
     {
       /* both plans have the same range terms we will check now the key filter terms */
       if (a_filter > b_filter)
@@ -11018,11 +11070,11 @@ qo_plan_iscan_terms_cmp (QO_PLAN * a, QO_PLAN * b)
       /* both have the same number of index pages and pkeys_size */
       return PLAN_COMP_EQ;
     }
-  else if (a_range > 0 && bitset_subset (&(a->plan_un.scan.terms), &(b->plan_un.scan.terms)))
+  else if (a_range > 0 && bitset_subset (& (a->plan_un.scan.terms), & (b->plan_un.scan.terms)))
     {
       return PLAN_COMP_LT;
     }
-  else if (b_range > 0 && bitset_subset (&(b->plan_un.scan.terms), &(a->plan_un.scan.terms)))
+  else if (b_range > 0 && bitset_subset (& (b->plan_un.scan.terms), & (a->plan_un.scan.terms)))
     {
       return PLAN_COMP_GT;
     }
@@ -11076,7 +11128,7 @@ qo_plan_iscan_terms_cmp (QO_PLAN * a, QO_PLAN * b)
  *   b(in):
  */
 static QO_PLAN_COMPARE_RESULT
-qo_group_by_skip_plans_cmp (QO_PLAN * a, QO_PLAN * b)
+qo_group_by_skip_plans_cmp (QO_PLAN *a, QO_PLAN *b)
 {
   QO_INDEX_ENTRY *a_ent, *b_ent;
 
@@ -11133,7 +11185,7 @@ qo_group_by_skip_plans_cmp (QO_PLAN * a, QO_PLAN * b)
  *   b(in):
  */
 static QO_PLAN_COMPARE_RESULT
-qo_order_by_skip_plans_cmp (QO_PLAN * a, QO_PLAN * b)
+qo_order_by_skip_plans_cmp (QO_PLAN *a, QO_PLAN *b)
 {
   QO_INDEX_ENTRY *a_ent, *b_ent;
 
@@ -11190,7 +11242,7 @@ qo_order_by_skip_plans_cmp (QO_PLAN * a, QO_PLAN * b)
  *   plan (in): input index plan to be analyzed
  */
 static bool
-qo_check_orderby_skip_descending (QO_PLAN * plan)
+qo_check_orderby_skip_descending (QO_PLAN *plan)
 {
   bool orderby_skip = false;
   QO_ENV *env;
@@ -11253,8 +11305,8 @@ qo_check_orderby_skip_descending (QO_PLAN * plan)
  *   plan (in): input index plan to be analyzed
  */
 static bool
-qo_check_skip_term (QO_ENV * env, BITSET visited_segs, QO_TERM * term, BITSET * visited_terms,
-		    BITSET * cur_visited_terms)
+qo_check_skip_term (QO_ENV *env, BITSET visited_segs, QO_TERM *term, BITSET *visited_terms,
+		    BITSET *cur_visited_terms)
 {
   BITSET remaining_terms, connected_segs, all_visited_terms, eq_visited_segs;
   BITSET_ITERATOR bi;
@@ -11263,7 +11315,7 @@ qo_check_skip_term (QO_ENV * env, BITSET visited_segs, QO_TERM * term, BITSET * 
   bool result;
 
   /* check unvisited segments */
-  if (!bitset_subset (&visited_segs, &(QO_TERM_SEGS (term))))
+  if (!bitset_subset (&visited_segs, & (QO_TERM_SEGS (term))))
     {
       return false;
     }
@@ -11283,7 +11335,7 @@ qo_check_skip_term (QO_ENV * env, BITSET visited_segs, QO_TERM * term, BITSET * 
       if (QO_TERM_EQCLASS (tmp_term) == QO_TERM_EQCLASS (term))
 	{
 	  bitset_add (&remaining_terms, i);
-	  bitset_union (&eq_visited_segs, &(QO_TERM_SEGS (tmp_term)));
+	  bitset_union (&eq_visited_segs, & (QO_TERM_SEGS (tmp_term)));
 	}
     }
 
@@ -11302,10 +11354,10 @@ qo_check_skip_term (QO_ENV * env, BITSET visited_segs, QO_TERM * term, BITSET * 
 	{
 	  tmp_term = QO_ENV_TERM (env, i);
 
-	  if (bitset_is_empty (&connected_segs) || bitset_intersects (&connected_segs, &(QO_TERM_SEGS (tmp_term))))
+	  if (bitset_is_empty (&connected_segs) || bitset_intersects (&connected_segs, & (QO_TERM_SEGS (tmp_term))))
 	    {
 	      /* first time or connected segs */
-	      bitset_union (&connected_segs, &(QO_TERM_SEGS (tmp_term)));
+	      bitset_union (&connected_segs, & (QO_TERM_SEGS (tmp_term)));
 	      bitset_remove (&remaining_terms, i);
 	    }
 	}
@@ -11318,7 +11370,7 @@ qo_check_skip_term (QO_ENV * env, BITSET visited_segs, QO_TERM * term, BITSET * 
       prev_card = bitset_cardinality (&remaining_terms);
     }
 
-  if (bitset_subset (&connected_segs, &(QO_TERM_SEGS (term))))
+  if (bitset_subset (&connected_segs, & (QO_TERM_SEGS (term))))
     {
       /* already evaluated */
       result = true;
@@ -11343,7 +11395,7 @@ end:
  *   plan(in):
  */
 bool
-qo_is_iscan_from_groupby (QO_PLAN * plan)
+qo_is_iscan_from_groupby (QO_PLAN *plan)
 {
   if (plan && plan->plan_type == QO_PLANTYPE_SCAN && plan->plan_un.scan.scan_method == QO_SCANMETHOD_INDEX_GROUPBY_SCAN)
     {
@@ -11360,7 +11412,7 @@ qo_is_iscan_from_groupby (QO_PLAN * plan)
  *  return: 1 if the index can be used, 0 elseware
  */
 static int
-qo_validate_index_for_groupby (QO_ENV * env, QO_NODE_INDEX_ENTRY * ni_entryp)
+qo_validate_index_for_groupby (QO_ENV *env, QO_NODE_INDEX_ENTRY *ni_entryp)
 {
   bool key_notnull = false;	/* init */
   QO_INDEX_ENTRY *index_entryp;
@@ -11420,7 +11472,7 @@ end:
  *   plan (in): input index plan to be analyzed
  */
 static bool
-qo_check_groupby_skip_descending (QO_PLAN * plan, PT_NODE * list)
+qo_check_groupby_skip_descending (QO_PLAN *plan, PT_NODE *list)
 {
   bool groupby_skip = false;
   QO_ENV *env;
@@ -11486,7 +11538,7 @@ qo_check_groupby_skip_descending (QO_PLAN * plan, PT_NODE * list)
  *
  */
 PT_NODE *
-qo_plan_compute_iscan_sort_list (QO_PLAN * root, PT_NODE * group_by, bool * is_index_w_prefix,
+qo_plan_compute_iscan_sort_list (QO_PLAN *root, PT_NODE *group_by, bool *is_index_w_prefix,
 				 bool for_min_max_optimize)
 {
   QO_PLAN *plan;
@@ -11560,7 +11612,7 @@ qo_plan_compute_iscan_sort_list (QO_PLAN * root, PT_NODE * group_by, bool * is_i
   /* pointer to linked list of index node, 'head' field(QO_INDEX_ENTRY strucutre) of QO_NODE_INDEX_ENTRY */
   index_entryp = (ni_entryp)->head;
 
-  nterms = bitset_cardinality (&(plan->plan_un.scan.terms));
+  nterms = bitset_cardinality (& (plan->plan_un.scan.terms));
   if (nterms > 0)
     {
       equi_nterms = plan->plan_un.scan.index_equi ? nterms : nterms - 1;
@@ -11599,7 +11651,8 @@ qo_plan_compute_iscan_sort_list (QO_PLAN * root, PT_NODE * group_by, bool * is_i
 
   key_type = index_entryp->key_type;
   if (key_type == NULL)
-    {				/* is invalid case */
+    {
+      /* is invalid case */
       assert (false);
       goto exit_on_end;		/* nop */
     }
@@ -11651,7 +11704,8 @@ qo_plan_compute_iscan_sort_list (QO_PLAN * root, PT_NODE * group_by, bool * is_i
 
       seg_idx = (index_entryp->seg_idxs[i]);
       if (seg_idx == -1)
-	{			/* not exist in query */
+	{
+	  /* not exist in query */
 	  break;		/* give up */
 	}
 
@@ -11681,7 +11735,7 @@ qo_plan_compute_iscan_sort_list (QO_PLAN * root, PT_NODE * group_by, bool * is_i
 	    }
 
 	  /* skip segment of const eq term */
-	  terms = &(QO_SEG_INDEX_TERMS (seg));
+	  terms = & (QO_SEG_INDEX_TERMS (seg));
 	  is_const_eq_term = false;
 	  for (j = bitset_iterate (terms, &bi); j != -1; j = bitset_next_member (&bi))
 	    {
@@ -11752,7 +11806,8 @@ qo_plan_compute_iscan_sort_list (QO_PLAN * root, PT_NODE * group_by, bool * is_i
 	}
 
       if (pos_descr.pos_no <= 0 || col == NULL)
-	{			/* not found i-th key element */
+	{
+	  /* not found i-th key element */
 	  break;		/* give up */
 	}
 
@@ -11782,7 +11837,7 @@ exit_on_end:
  *   plan(in):
  */
 bool
-qo_is_interesting_order_scan (QO_PLAN * plan)
+qo_is_interesting_order_scan (QO_PLAN *plan)
 {
   if (qo_is_iscan (plan) || qo_is_iscan_from_groupby (plan) || qo_is_iscan_from_orderby (plan))
     {
@@ -11799,7 +11854,7 @@ qo_is_interesting_order_scan (QO_PLAN * plan)
  * plan (in) : plan to verify
  */
 static bool
-qo_plan_is_orderby_skip_candidate (QO_PLAN * plan)
+qo_plan_is_orderby_skip_candidate (QO_PLAN *plan)
 {
   PARSER_CONTEXT *parser;
   PT_NODE *order_by, *statement, *entity;
@@ -11908,7 +11963,7 @@ cleanup:
  * plan (in) :
  */
 static bool
-qo_is_sort_limit (QO_PLAN * plan)
+qo_is_sort_limit (QO_PLAN *plan)
 {
   return (plan != NULL && plan->plan_type == QO_PLANTYPE_SORT && plan->plan_un.sort.sort_type == SORT_LIMIT);
 }
@@ -11919,7 +11974,7 @@ qo_is_sort_limit (QO_PLAN * plan)
  * plan (in) : plan to verify
  */
 bool
-qo_has_sort_limit_subplan (QO_PLAN * plan)
+qo_has_sort_limit_subplan (QO_PLAN *plan)
 {
   if (plan == NULL)
     {
@@ -11957,7 +12012,7 @@ qo_has_sort_limit_subplan (QO_PLAN * plan)
  * plan (in) : plan to check
  */
 static int
-qo_check_like_recompile_candidate (QO_PLAN * plan, void *arg)
+qo_check_like_recompile_candidate (QO_PLAN *plan, void *arg)
 {
   BITSET terms_set, temp_segs_set;
   int term_idx, seg_idx;
@@ -11972,9 +12027,9 @@ qo_check_like_recompile_candidate (QO_PLAN * plan, void *arg)
   env = (plan->info)->env;
   bitset_init (&terms_set, env);
 
-  bitset_assign (&terms_set, &(plan->sarged_terms));
-  bitset_union (&terms_set, &(plan->plan_un.scan.terms));
-  bitset_union (&terms_set, &(plan->plan_un.scan.kf_terms));
+  bitset_assign (&terms_set, & (plan->sarged_terms));
+  bitset_union (&terms_set, & (plan->plan_un.scan.terms));
+  bitset_union (&terms_set, & (plan->plan_un.scan.kf_terms));
 
   for (term_idx = bitset_iterate (&terms_set, &terms_iter); term_idx != -1; term_idx = bitset_next_member (&terms_iter))
     {
@@ -12011,7 +12066,7 @@ qo_check_like_recompile_candidate (QO_PLAN * plan, void *arg)
 }
 
 int
-qo_has_like_recompile_candidate (QO_PLAN * plan, void *arg)
+qo_has_like_recompile_candidate (QO_PLAN *plan, void *arg)
 {
   return qo_walk_plan_tree (plan, qo_check_like_recompile_candidate, arg);
 }
@@ -12026,7 +12081,7 @@ qo_has_like_recompile_candidate (QO_PLAN * plan, void *arg)
  *   plan(in):
  */
 static json_t *
-qo_plan_scan_print_json (QO_PLAN * plan)
+qo_plan_scan_print_json (QO_PLAN *plan)
 {
   BITSET_ITERATOR bi;
   QO_ENV *env;
@@ -12063,17 +12118,17 @@ qo_plan_scan_print_json (QO_PLAN * plan)
       env = (plan->info)->env;
       range = json_array ();
 
-      for (i = bitset_iterate (&(plan->plan_un.scan.terms), &bi); i != -1; i = bitset_next_member (&bi))
+      for (i = bitset_iterate (& (plan->plan_un.scan.terms), &bi); i != -1; i = bitset_next_member (&bi))
 	{
 	  json_array_append_new (range, json_string (qo_term_string (QO_ENV_TERM (env, i), buf)));
 	}
 
       json_object_set_new (scan, "key range", range);
 
-      if (bitset_cardinality (&(plan->plan_un.scan.kf_terms)) > 0)
+      if (bitset_cardinality (& (plan->plan_un.scan.kf_terms)) > 0)
 	{
 	  filter = json_array ();
-	  for (i = bitset_iterate (&(plan->plan_un.scan.kf_terms), &bi); i != -1; i = bitset_next_member (&bi))
+	  for (i = bitset_iterate (& (plan->plan_un.scan.kf_terms), &bi); i != -1; i = bitset_next_member (&bi))
 	    {
 	      json_array_append_new (filter, json_string (qo_term_string (QO_ENV_TERM (env, i), buf)));
 	    }
@@ -12114,7 +12169,7 @@ qo_plan_scan_print_json (QO_PLAN * plan)
  *   plan(in):
  */
 static json_t *
-qo_plan_sort_print_json (QO_PLAN * plan)
+qo_plan_sort_print_json (QO_PLAN *plan)
 {
   json_t *sort, *subplan = NULL;
   const char *type;
@@ -12168,7 +12223,7 @@ qo_plan_sort_print_json (QO_PLAN * plan)
  *   plan(in):
  */
 static json_t *
-qo_plan_join_print_json (QO_PLAN * plan)
+qo_plan_join_print_json (QO_PLAN *plan)
 {
   json_t *join, *outer, *inner;
   const char *type, *method = "";
@@ -12197,7 +12252,7 @@ qo_plan_join_print_json (QO_PLAN * plan)
   switch (plan->plan_un.join.join_type)
     {
     case JOIN_INNER:
-      if (!bitset_is_empty (&(plan->plan_un.join.join_terms)))
+      if (!bitset_is_empty (& (plan->plan_un.join.join_terms)))
 	{
 	  type = "inner join";
 	}
@@ -12247,7 +12302,7 @@ qo_plan_join_print_json (QO_PLAN * plan)
  *   plan(in):
  */
 static json_t *
-qo_plan_follow_print_json (QO_PLAN * plan)
+qo_plan_follow_print_json (QO_PLAN *plan)
 {
   json_t *head, *follow;
   char buf[257] = { '\0', };
@@ -12267,7 +12322,7 @@ qo_plan_follow_print_json (QO_PLAN * plan)
  *   plan(in):
  */
 static json_t *
-qo_plan_print_json (QO_PLAN * plan)
+qo_plan_print_json (QO_PLAN *plan)
 {
   json_t *json = NULL;
 
@@ -12305,7 +12360,7 @@ qo_plan_print_json (QO_PLAN * plan)
  *   plan(in):
  */
 void
-qo_top_plan_print_json (PARSER_CONTEXT * parser, xasl_node * xasl, PT_NODE * select, QO_PLAN * plan)
+qo_top_plan_print_json (PARSER_CONTEXT *parser, xasl_node *xasl, PT_NODE *select, QO_PLAN *plan)
 {
   json_t *json;
   unsigned int save_custom;
@@ -12357,7 +12412,7 @@ qo_top_plan_print_json (PARSER_CONTEXT * parser, xasl_node * xasl, PT_NODE * sel
  *   indent(in):
  */
 static void
-qo_plan_scan_print_text (FILE * fp, QO_PLAN * plan, int indent)
+qo_plan_scan_print_text (FILE *fp, QO_PLAN *plan, int indent)
 {
   BITSET_ITERATOR bi;
   QO_ENV *env;
@@ -12392,15 +12447,15 @@ qo_plan_scan_print_text (FILE * fp, QO_PLAN * plan, int indent)
 
       bool first = true;
 
-      for (i = bitset_iterate (&(plan->plan_un.scan.terms), &bi); i != -1; i = bitset_next_member (&bi))
+      for (i = bitset_iterate (& (plan->plan_un.scan.terms), &bi); i != -1; i = bitset_next_member (&bi))
 	{
 	  fprintf (fp, "key range: %s", qo_term_string (QO_ENV_TERM (env, i), buf));
 	  first = false;
 	}
 
-      if (bitset_cardinality (&(plan->plan_un.scan.kf_terms)) > 0)
+      if (bitset_cardinality (& (plan->plan_un.scan.kf_terms)) > 0)
 	{
-	  for (i = bitset_iterate (&(plan->plan_un.scan.kf_terms), &bi); i != -1; i = bitset_next_member (&bi))
+	  for (i = bitset_iterate (& (plan->plan_un.scan.kf_terms), &bi); i != -1; i = bitset_next_member (&bi))
 	    {
 	      fprintf (fp, "%skey filter: %s", first ? "" : ", ", qo_term_string (QO_ENV_TERM (env, i), buf));
 	    }
@@ -12447,7 +12502,7 @@ qo_plan_scan_print_text (FILE * fp, QO_PLAN * plan, int indent)
  *   indent(in):
  */
 static void
-qo_plan_sort_print_text (FILE * fp, QO_PLAN * plan, int indent)
+qo_plan_sort_print_text (FILE *fp, QO_PLAN *plan, int indent)
 {
   const char *type;
 
@@ -12497,7 +12552,7 @@ qo_plan_sort_print_text (FILE * fp, QO_PLAN * plan, int indent)
  *   indent(in):
  */
 static void
-qo_plan_join_print_text (FILE * fp, QO_PLAN * plan, int indent)
+qo_plan_join_print_text (FILE *fp, QO_PLAN *plan, int indent)
 {
   const char *type, *method = "";
 
@@ -12526,7 +12581,7 @@ qo_plan_join_print_text (FILE * fp, QO_PLAN * plan, int indent)
   switch (plan->plan_un.join.join_type)
     {
     case JOIN_INNER:
-      if (!bitset_is_empty (&(plan->plan_un.join.join_terms)))
+      if (!bitset_is_empty (& (plan->plan_un.join.join_terms)))
 	{
 	  type = "inner join";
 	}
@@ -12573,7 +12628,7 @@ qo_plan_join_print_text (FILE * fp, QO_PLAN * plan, int indent)
  *   indent(in):
  */
 static void
-qo_plan_follow_print_text (FILE * fp, QO_PLAN * plan, int indent)
+qo_plan_follow_print_text (FILE *fp, QO_PLAN *plan, int indent)
 {
   char buf[257] = { '\0', };
   indent += 2;
@@ -12591,7 +12646,7 @@ qo_plan_follow_print_text (FILE * fp, QO_PLAN * plan, int indent)
  *   indent(in):
  */
 static void
-qo_plan_print_text (FILE * fp, QO_PLAN * plan, int indent)
+qo_plan_print_text (FILE *fp, QO_PLAN *plan, int indent)
 {
   switch (plan->plan_type)
     {
@@ -12625,7 +12680,7 @@ qo_plan_print_text (FILE * fp, QO_PLAN * plan, int indent)
  *   plan(in):
  */
 void
-qo_top_plan_print_text (PARSER_CONTEXT * parser, xasl_node * xasl, PT_NODE * select, QO_PLAN * plan)
+qo_top_plan_print_text (PARSER_CONTEXT *parser, xasl_node *xasl, PT_NODE *select, QO_PLAN *plan)
 {
   size_t sizeloc;
   char *ptr, *sql;
@@ -12699,7 +12754,7 @@ qo_top_plan_print_text (PARSER_CONTEXT * parser, xasl_node * xasl, PT_NODE * sel
  *   plan(in): Query plan node to check (must be a hash join plan).
  */
 QO_PLAN_PARALLEL_OPT_USE
-qo_check_hjoin_for_parallel_opt (QO_PLAN * plan)
+qo_check_hjoin_for_parallel_opt (QO_PLAN *plan)
 {
   PARSER_CONTEXT *parser = NULL;
   PT_NODE *tree = NULL, *expr = NULL;

--- a/src/optimizer/query_planner_constants.h
+++ b/src/optimizer/query_planner_constants.h
@@ -38,7 +38,9 @@
 
 #define TEMP_SETUP_COST 5.0
 #define QO_CPU_WEIGHT 0.0025
-#define ISCAN_OID_ACCESS_OVERHEAD 20	/* need to be adjusted */
+/* Per-OID heap-access CPU penalty for NON-covering index scans (covering scans: 0).
+ * Lowered 20 -> 5 to favor index scan when low/stale leading-column NDV inflates sel via 1/pkeys[0]. TODO: per-index clustering factor. */
+#define ISCAN_OID_ACCESS_OVERHEAD 5
 #define MJ_CPU_OVERHEAD_FACTOR 20
 #define HJ_BUILD_CPU_OVERHEAD_FACTOR 30
 #define HJ_PROBE_CPU_OVERHEAD_FACTOR 20

--- a/src/optimizer/query_planner_constants.h
+++ b/src/optimizer/query_planner_constants.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef _QUERY_PLANNER_CONSTANTS_H_
+#define _QUERY_PLANNER_CONSTANTS_H_
+
+#define TEST_DUMP_PLAN_SCAN_COST 0
+#define TEST_DUMP_PLAN_SORT_COST 0
+#define TEST_DUMP_PLAN_JOIN_COST 0
+#define TEST_DUMP_PLAN_FOLLOW_COST 0
+
+#define TEST_HASH_JOIN_ENABLE 0
+#define TEST_HASH_JOIN_FORCE_ENABLE 0
+
+#define INDENT_INCR		4
+#define INDENT_FMT		"%*c"
+#define TITLE_WIDTH		7
+#define TITLE_FMT		"%-" __STR(TITLE_WIDTH) "s"
+#define INDENTED_TITLE_FMT	INDENT_FMT TITLE_FMT
+#define __STR(n)		__VAL(n)
+#define __VAL(n)		#n
+#define SORT_SPEC_FMT(spec)   "%d %s %s", (spec)->pos_descr.pos_no + 1,   ((spec)->s_order == S_ASC ? "asc" : "desc"),   ((spec)->s_nulls == S_NULLS_FIRST ? "nulls first" : "nulls last")
+
+#define TEMP_SETUP_COST 5.0
+#define QO_CPU_WEIGHT 0.0025
+#define ISCAN_OID_ACCESS_OVERHEAD 20	/* need to be adjusted */
+#define MJ_CPU_OVERHEAD_FACTOR 20
+#define HJ_BUILD_CPU_OVERHEAD_FACTOR 30
+#define HJ_PROBE_CPU_OVERHEAD_FACTOR 20
+#define HJ_FILE_IO_WEIGHT 0.5	/* Unused */
+#define ISCAN_IO_HIT_RATIO 0.5
+#define QO_NLJOIN_MEMOIZE_HIT_COST_RATIO 0.01
+#define SSCAN_DEFAULT_CARD 100
+#define GUESSED_BIND_LIMIT_CARD 2000	/* When limit is a bind variable, assume that fewer rows will be assigned. */
+
+#define RBO_CHECK_COST 50
+#define RBO_CHECK_RATIO 1.2
+#define RBO_CHECK_LIMIT_RATIO 10
+
+/* generic predicate evaluation */
+#define QO_COST_WEIGHT_PRED_DEFAULT            1.00
+
+/* numeric/date equality or simple scalar comparison */
+#define QO_COST_WEIGHT_NUMERIC_COMPARE         1.00
+#define QO_COST_WEIGHT_TEMPORAL_COMPARE        1.05
+
+/* string comparisons */
+#define QO_COST_WEIGHT_STRING_EQUAL            3.00
+#define QO_COST_WEIGHT_STRING_RANGE            3.25
+#define QO_COST_WEIGHT_STRING_COLLATION        3.50
+
+/* LIKE family */
+#define QO_COST_WEIGHT_LIKE_PREFIX             3.50	/* e.g. 'abc%' */
+#define QO_COST_WEIGHT_LIKE_CONTAINS           10.00	/* e.g. '%abc%' */
+#define QO_COST_WEIGHT_LIKE_COMPLEX            14.00	/* mixed %, _, escapes */
+
+/* joins */
+#define QO_COST_WEIGHT_JOIN_DEFAULT            1.00
+#define QO_COST_WEIGHT_JOIN_STRING_EQUAL       1.10
+#define QO_COST_WEIGHT_JOIN_STRING_RANGE       1.25
+
+/* optional guard rails */
+#define QO_COST_WEIGHT_MIN                     0.50
+#define QO_COST_WEIGHT_MAX                     5.00
+
+/* sequential scan */
+#define QO_SSCAN_FILTER_CPU_FACTOR             1.00
+
+#define DEFAULT_NULL_SELECTIVITY (double) 0.01
+#define DEFAULT_EXISTS_SELECTIVITY (double) 0.1
+#define DEFAULT_SELECTIVITY (double) 0.1
+#define DEFAULT_EQUAL_SELECTIVITY (double) 0.001
+#define DEFAULT_EQUIJOIN_SELECTIVITY (double) 0.001
+#define DEFAULT_COMP_SELECTIVITY (double) 0.1
+#define DEFAULT_BETWEEN_SELECTIVITY (double) 0.01
+#define DEFAULT_IN_SELECTIVITY (double) 0.01
+#define DEFAULT_RANGE_SELECTIVITY (double) 0.1
+
+#endif /* _QUERY_PLANNER_CONSTANTS_H_ */

--- a/src/optimizer/query_planner_internal.h
+++ b/src/optimizer/query_planner_internal.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef _QUERY_PLANNER_INTERNAL_H_
+#define _QUERY_PLANNER_INTERNAL_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <assert.h>
+#if !defined(WINDOWS)
+#include <values.h>
+#endif /* !WINDOWS */
+#include "jansson.h"
+
+#include "parser.h"
+#include "object_primitive.h"
+#include "optimizer.h"
+#include "query_planner.h"
+#include "query_graph.h"
+#include "environment_variable.h"
+#include "misc_string.h"
+#include "system_parameter.h"
+#include "parser.h"
+#include "parser_message.h"
+#include "intl_support.h"
+#include "storage_common.h"
+#include "xasl_analytic.hpp"
+#include "xasl_generation.h"
+#include "schema_manager.h"
+#include "network_interface_cl.h"
+#include "dbtype.h"
+#include "regu_var.hpp"
+#include "histogram_cl.hpp"
+#include "query_planner_constants.h"
+
+double qo_or_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel);
+double qo_and_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel);
+double qo_not_selectivity (QO_ENV * env, double sel);
+double qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+double qo_comp_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+double qo_between_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+double qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+double qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+double qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr);
+int qo_index_cardinality (QO_ENV * env, PT_NODE * attr);
+
+#endif /* _QUERY_PLANNER_INTERNAL_H_ */

--- a/src/optimizer/query_planner_selectivity.c
+++ b/src/optimizer/query_planner_selectivity.c
@@ -1096,15 +1096,46 @@ qo_classify (PT_NODE * attr)
 double
 qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr)
 {
-  /* Base LIKE selectivity: the system parameter PRM_ID_LIKE_TERM_SELECTIVITY.
-   * Histogram/pattern-based LIKE selectivity is added in the LIKE-selectivity layer (PR L2). */
-  PT_NODE *lhs = pt_expr->info.expr.arg1;
-  PT_NODE *rhs = pt_expr->info.expr.arg2;
+  PT_NODE *lhs, *rhs;
+  DB_VALUE *host_var = NULL;
+  PRED_CLASS pc_lhs, pc_rhs;
 
-  if (lhs == NULL || rhs == NULL)
+  double selectivity = 0.0;
+
+  PT_NODE *like_node = pt_expr;
+  bool success = false;
+
+  lhs = like_node->info.expr.arg1;
+  rhs = like_node->info.expr.arg2;
+
+  if (lhs && rhs)
     {
-      return 0.0;
+      pc_lhs = qo_classify (lhs);
+      pc_rhs = qo_classify (rhs);
+
+      if (pc_lhs == PC_ATTR)
+	{
+	  if (pc_rhs == PC_CONST)
+	    {
+	      host_var = &rhs->info.value.db_value;
+	    }
+	  else if (pc_rhs == PC_HOST_VAR)
+	    {
+	      host_var = &env->parser->host_variables[rhs->info.host_var.index];
+	    }
+
+	  histogram_get_like_selectivity (lhs, host_var, &selectivity, &success);
+
+	  if (!success)
+	    {
+	      selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+	    }
+	}
+      else
+	{
+	  selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+	}
     }
 
-  return (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+  return selectivity;
 }

--- a/src/optimizer/query_planner_selectivity.c
+++ b/src/optimizer/query_planner_selectivity.c
@@ -1,0 +1,1110 @@
+/*
+ * Copyright 2008 Search Solution Corporation
+ * Copyright 2016 CUBRID Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ident "$Id$"
+
+#include "config.h"
+#include "query_planner_internal.h"
+#include "query_planner_constants.h"
+
+double
+qo_expr_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  double lhs_selectivity, rhs_selectivity, selectivity, total_selectivity;
+  PT_NODE *node;
+  bool not_null_calculated = false;
+
+  QO_ASSERT (env, pt_expr != NULL);
+  QO_ASSERT (env, pt_expr->node_type == PT_EXPR);
+
+  selectivity = 0.0;
+  total_selectivity = 0.0;
+
+  /* traverse OR list */
+  for (node = pt_expr; node; node = node->or_next)
+    {
+      switch (node->info.expr.op)
+	{
+	case PT_OR:
+	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
+	  rhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg2);
+	  selectivity = qo_or_selectivity (env, lhs_selectivity, rhs_selectivity);
+	  break;
+
+	case PT_AND:
+	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
+	  rhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg2);
+	  selectivity = qo_and_selectivity (env, lhs_selectivity, rhs_selectivity);
+	  break;
+
+	case PT_NOT:
+	  lhs_selectivity = qo_expr_selectivity (env, node->info.expr.arg1);
+	  selectivity = qo_not_selectivity (env, lhs_selectivity);
+	  break;
+
+	case PT_EQ:
+	  selectivity = qo_equal_selectivity (env, node);
+	  break;
+
+	case PT_NE:
+	  lhs_selectivity = qo_equal_selectivity (env, node);
+	  selectivity = qo_not_selectivity (env, lhs_selectivity);
+	  break;
+
+	case PT_NULLSAFE_EQ:
+	  selectivity = qo_equal_selectivity (env, node);
+	  break;
+
+	case PT_GE:
+	case PT_GT:
+	case PT_LT:
+	case PT_LE:
+	  selectivity = qo_comp_selectivity (env, node);
+	  break;
+
+	case PT_BETWEEN:
+	  selectivity = qo_between_selectivity (env, node);
+	  break;
+
+	case PT_NOT_BETWEEN:
+	  lhs_selectivity = qo_between_selectivity (env, node);
+	  selectivity = qo_not_selectivity (env, lhs_selectivity);
+	  break;
+
+	case PT_RANGE:
+	  selectivity = qo_range_selectivity (env, node);
+	  break;
+
+	case PT_LIKE_ESCAPE:
+	  selectivity = (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+	  break;
+	case PT_LIKE:
+	  {
+	    selectivity = qo_like_selectivity (env, node);
+	    break;
+	  }
+	case PT_NOT_LIKE:
+	  {
+	    selectivity = 1 - qo_like_selectivity (env, node);
+	    break;
+	  }
+	case PT_SETNEQ:
+	case PT_SETEQ:
+	case PT_SUPERSETEQ:
+	case PT_SUPERSET:
+	case PT_SUBSET:
+	case PT_SUBSETEQ:
+	case PT_IS:
+	case PT_XOR:
+	  selectivity = DEFAULT_SELECTIVITY;
+	  break;
+
+	case PT_IS_NOT:
+	  selectivity = qo_not_selectivity (env, DEFAULT_SELECTIVITY);
+	  break;
+
+	case PT_EQ_SOME:
+	case PT_NE_SOME:
+	case PT_GE_SOME:
+	case PT_GT_SOME:
+	case PT_LT_SOME:
+	case PT_LE_SOME:
+	case PT_EQ_ALL:
+	case PT_NE_ALL:
+	case PT_GE_ALL:
+	case PT_GT_ALL:
+	case PT_LT_ALL:
+	case PT_LE_ALL:
+	case PT_IS_IN:
+	  selectivity = qo_all_some_in_selectivity (env, node);
+	  break;
+
+	case PT_IS_NOT_IN:
+	  lhs_selectivity = qo_all_some_in_selectivity (env, node);
+	  selectivity = qo_not_selectivity (env, lhs_selectivity);
+	  break;
+
+	case PT_IS_NULL:
+	  if (pt_expr->info.expr.arg1->node_type == PT_NAME && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
+	    {
+	      selectivity = pt_expr->info.expr.arg1->info.name.null_frequency;
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_NULL_SELECTIVITY;
+	    }
+	  not_null_calculated = true;
+	  break;
+
+	case PT_IS_NOT_NULL:
+	  if (pt_expr->info.expr.arg1->node_type == PT_NAME && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
+	    {
+	      selectivity = pt_expr->info.expr.arg1->info.name.null_frequency;
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_NULL_SELECTIVITY;
+	    }
+	  selectivity = 1 - selectivity;
+	  not_null_calculated = true;
+	  break;
+
+	case PT_EXISTS:
+	  selectivity = DEFAULT_EXISTS_SELECTIVITY;	/* make a guess */
+	  break;
+
+	default:
+	  break;
+	}
+
+      if (!not_null_calculated)
+	{
+	  if (pt_expr->info.expr.arg1 && pt_expr->info.expr.arg1->node_type == PT_NAME
+	      && pt_expr->info.expr.arg1->info.name.null_frequency >= 0.0)
+	    {
+	      selectivity = selectivity * (1 - pt_expr->info.expr.arg1->info.name.null_frequency);
+	    }
+	  if (pt_expr->info.expr.arg2 && pt_expr->info.expr.arg2->node_type == PT_NAME
+	      && pt_expr->info.expr.arg2->info.name.null_frequency >= 0.0)
+	    {
+	      selectivity = selectivity * (1 - pt_expr->info.expr.arg2->info.name.null_frequency);
+	    }
+	}
+
+      total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);
+      total_selectivity = MAX (total_selectivity, 0.0);
+      total_selectivity = MIN (total_selectivity, 1.0);
+    }
+
+  return total_selectivity;
+}
+
+double
+qo_or_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel)
+{
+  double result;
+
+  QO_ASSERT (env, lhs_sel >= 0.0);
+  QO_ASSERT (env, lhs_sel <= 1.0);
+  QO_ASSERT (env, rhs_sel >= 0.0);
+  QO_ASSERT (env, rhs_sel <= 1.0);
+
+  result = lhs_sel + rhs_sel - (lhs_sel * rhs_sel);
+
+  return result;
+}
+
+double
+qo_and_selectivity (QO_ENV * env, double lhs_sel, double rhs_sel)
+{
+  double result;
+
+  QO_ASSERT (env, lhs_sel >= 0.0);
+  QO_ASSERT (env, lhs_sel <= 1.0);
+  QO_ASSERT (env, rhs_sel >= 0.0);
+  QO_ASSERT (env, rhs_sel <= 1.0);
+
+  result = lhs_sel * rhs_sel;
+
+  return result;
+}
+
+double
+qo_not_selectivity (QO_ENV * env, double sel)
+{
+  QO_ASSERT (env, sel >= 0.0);
+  QO_ASSERT (env, sel <= 1.0);
+
+  return 1.0 - sel;
+}
+
+double
+qo_equal_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  PT_NODE *lhs, *rhs, *multi_attr;
+  DB_VALUE *host_var;
+  PRED_CLASS pc_lhs, pc_rhs;
+  int lhs_icard, rhs_icard, icard;
+  double selectivity;
+
+  lhs = pt_expr->info.expr.arg1;
+  rhs = pt_expr->info.expr.arg2;
+
+  /* the class of lhs and rhs */
+  pc_lhs = qo_classify (lhs);
+  pc_rhs = qo_classify (rhs);
+
+  selectivity = DEFAULT_EQUAL_SELECTIVITY;
+
+  bool success = false;
+
+  switch (pc_lhs)
+    {
+    case PC_ATTR:
+
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  {
+	    /* attr = attr */
+	    bool success = false;
+	    double eqjoin_selectivity = 0.0;
+	    histogram_get_eqjoin_selectivity (lhs, rhs, &eqjoin_selectivity, &success);
+	    if (success)
+	      {
+		selectivity = eqjoin_selectivity;
+	      }
+	    else
+	      {
+
+		/* check for indexes on either of the attributes */
+		lhs_icard = qo_index_cardinality (env, lhs);
+		rhs_icard = qo_index_cardinality (env, rhs);
+
+		icard = MAX (lhs_icard, rhs_icard);
+		if (icard != 0)
+		  {
+		    selectivity = (1.0 / icard);
+		  }
+		else
+		  {
+		    selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
+		  }
+	      }
+	  }
+	  break;
+
+	case PC_CONST:
+	case PC_HOST_VAR:
+	  if (pc_rhs == PC_HOST_VAR)
+	    {
+	      host_var = &env->parser->host_variables[rhs->info.host_var.index];
+	    }
+	  else
+	    {
+	      host_var = &rhs->info.value.db_value;
+	    }
+	  histogram_get_equal_selectivity (lhs, host_var, &selectivity, &success);
+	  if (success)
+	    {
+	      break;
+	    }
+	  [[fallthrough]];
+
+	case PC_SUBQUERY:
+	case PC_SET:
+	case PC_OTHER:
+	  /* attr = const */
+
+	  /* check for index on the attribute.  NOTE: For an equality predicate, we treat subqueries as constants. */
+	  lhs_icard = qo_index_cardinality (env, lhs);
+	  if (lhs_icard != 0)
+	    {
+	      selectivity = (1.0 / lhs_icard);
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	    }
+
+	  break;
+
+	case PC_MULTI_ATTR:
+	  /* attr = (attr,attr) syntactic impossible case */
+	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	  break;
+	}
+
+      break;
+
+    case PC_CONST:
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  histogram_get_equal_selectivity (rhs, &lhs->info.value.db_value, &selectivity, &success);
+	  break;
+
+	default:
+	  break;
+	}
+      if (success)
+	{
+	  break;
+	}
+      [[fallthrough]];
+
+    case PC_HOST_VAR:
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  host_var = &env->parser->host_variables[lhs->info.host_var.index];
+	  histogram_get_equal_selectivity (rhs, host_var, &selectivity, &success);
+	  break;
+
+	default:
+	  break;
+	}
+      if (success)
+	{
+	  break;
+	}
+      [[fallthrough]];
+    case PC_SUBQUERY:
+    case PC_SET:
+    case PC_OTHER:
+
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  /* const = attr */
+
+	  /* check for index on the attribute.  NOTE: For an equality predicate, we treat subqueries as constants. */
+	  rhs_icard = qo_index_cardinality (env, rhs);
+	  if (rhs_icard != 0)
+	    {
+	      selectivity = (1.0 / rhs_icard);
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	    }
+
+	  break;
+
+	case PC_CONST:
+	case PC_HOST_VAR:
+	case PC_SUBQUERY:
+	case PC_SET:
+	case PC_OTHER:
+	  /* const = const */
+
+	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	  break;
+
+	case PC_MULTI_ATTR:
+	  /* const = (attr,attr) */
+	  multi_attr = rhs->info.function.arg_list;
+	  rhs_icard = 0;
+	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
+	    {
+	      /* get index cardinality */
+	      icard = qo_index_cardinality (env, multi_attr);
+	      if (icard <= 0)
+		{
+		  /* the only interesting case is PT_BETWEEN_EQ_NA */
+		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
+		}
+	      if (rhs_icard == 0)
+		{
+		  /* first time */
+		  rhs_icard = icard;
+		}
+	      else
+		{
+		  rhs_icard *= icard;
+		}
+	    }
+	  if (rhs_icard != 0)
+	    {
+	      selectivity = (1.0 / rhs_icard);
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	    }
+	  break;
+	}
+      break;
+
+    case PC_MULTI_ATTR:
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  /* (attr,attr) = attr  syntactic impossible case */
+	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	  break;
+
+	case PC_CONST:
+	case PC_HOST_VAR:
+	case PC_SUBQUERY:
+	case PC_SET:
+	case PC_OTHER:
+	  /* (attr,attr) = const */
+
+	  multi_attr = lhs->info.function.arg_list;
+	  lhs_icard = 0;
+	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
+	    {
+	      /* get index cardinality */
+	      icard = qo_index_cardinality (env, multi_attr);
+	      if (icard <= 0)
+		{
+		  /* the only interesting case is PT_BETWEEN_EQ_NA */
+		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
+		}
+	      if (lhs_icard == 0)
+		{
+		  /* first time */
+		  lhs_icard = icard;
+		}
+	      else
+		{
+		  lhs_icard *= icard;
+		}
+	    }
+	  if (lhs_icard != 0)
+	    {
+	      selectivity = (1.0 / lhs_icard);
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	    }
+	  break;
+
+	case PC_MULTI_ATTR:
+	  /* (attr,attr) = (attr,attr) */
+	  multi_attr = lhs->info.function.arg_list;
+	  lhs_icard = 0;
+	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
+	    {
+	      /* get index cardinality */
+	      icard = qo_index_cardinality (env, multi_attr);
+	      if (icard <= 0)
+		{
+		  /* the only interesting case is PT_BETWEEN_EQ_NA */
+		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
+		}
+	      if (lhs_icard == 0)
+		{
+		  /* first time */
+		  lhs_icard = icard;
+		}
+	      else
+		{
+		  lhs_icard *= icard;
+		}
+	    }
+
+	  multi_attr = rhs->info.function.arg_list;
+	  rhs_icard = 0;
+	  for ( /* none */ ; multi_attr; multi_attr = multi_attr->next)
+	    {
+	      /* get index cardinality */
+	      icard = qo_index_cardinality (env, multi_attr);
+	      if (icard <= 0)
+		{
+		  /* the only interesting case is PT_BETWEEN_EQ_NA */
+		  icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
+		}
+	      if (rhs_icard == 0)
+		{
+		  /* first time */
+		  rhs_icard = icard;
+		}
+	      else
+		{
+		  rhs_icard *= icard;
+		}
+	    }
+
+	  icard = MAX (lhs_icard, rhs_icard);
+	  if (icard != 0)
+	    {
+	      selectivity = (1.0 / icard);
+	    }
+	  else
+	    {
+	      selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
+	    }
+	  break;
+	}
+
+      break;
+      break;
+    }
+
+  return selectivity;
+}
+
+double
+qo_comp_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  PT_NODE *lhs, *rhs, *multi_attr;
+  PRED_CLASS pc_lhs, pc_rhs;
+  DB_VALUE *rhs_db_value;
+  DB_VALUE *lhs_db_value;
+  int lhs_icard, rhs_icard, icard;
+  double selectivity;
+
+  lhs = pt_expr->info.expr.arg1;
+  rhs = pt_expr->info.expr.arg2;
+
+  /* the class of lhs and rhs */
+  pc_lhs = qo_classify (lhs);
+  pc_rhs = qo_classify (rhs);
+
+  selectivity = DEFAULT_COMP_SELECTIVITY;
+
+  bool success = false;
+  switch (pc_lhs)
+    {
+    case PC_ATTR:
+
+      switch (pc_rhs)
+	{
+	case PC_ATTR:
+	  /* TODO: add histogram selectivity */
+	  break;
+
+	case PC_CONST:
+	case PC_HOST_VAR:
+	  {
+	    if (pc_rhs == PC_HOST_VAR)
+	      {
+		rhs_db_value = &env->parser->host_variables[rhs->info.host_var.index];
+	      }
+	    else
+	      {
+		rhs_db_value = &rhs->info.value.db_value;
+	      }
+
+	    if (pt_expr->info.expr.op == PT_GE)
+	      {
+		histogram_get_comp_selectivity (lhs, rhs_db_value, true, true, &selectivity, &success);
+	      }
+	    else if (pt_expr->info.expr.op == PT_GT)
+	      {
+		histogram_get_comp_selectivity (lhs, rhs_db_value, true, false, &selectivity, &success);
+	      }
+	    else if (pt_expr->info.expr.op == PT_LE)
+	      {
+		histogram_get_comp_selectivity (lhs, rhs_db_value, false, true, &selectivity, &success);
+	      }
+	    else if (pt_expr->info.expr.op == PT_LT)
+	      {
+		histogram_get_comp_selectivity (lhs, rhs_db_value, false, false, &selectivity, &success);
+	      }
+	  }
+	  break;
+
+	default:
+	  break;
+	}
+
+      break;
+
+    case PC_CONST:
+    case PC_HOST_VAR:
+      {
+	switch (pc_rhs)
+	  {
+	  case PC_ATTR:
+	    {
+	      if (pc_lhs == PC_HOST_VAR)
+		{
+		  lhs_db_value = &env->parser->host_variables[lhs->info.host_var.index];
+		}
+	      else
+		{
+		  lhs_db_value = &lhs->info.value.db_value;
+		}
+	      if (pt_expr->info.expr.op == PT_GE)
+		{
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, false, &selectivity, &success);
+		}
+	      else if (pt_expr->info.expr.op == PT_GT)
+		{
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, false, true, &selectivity, &success);
+		}
+	      else if (pt_expr->info.expr.op == PT_LE)
+		{
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, false, &selectivity, &success);
+		}
+	      else if (pt_expr->info.expr.op == PT_LT)
+		{
+		  histogram_get_comp_selectivity (rhs, lhs_db_value, true, true, &selectivity, &success);
+		}
+	      break;
+	    }
+	  default:
+	    break;
+	  }
+      }
+      break;
+
+    case PC_MULTI_ATTR:
+      switch (pc_rhs)
+	{
+	case PC_MULTI_ATTR:
+	  /* (attr,attr) = (attr,attr) */
+	  /* TODO: add histogram selectivity */
+	  break;
+
+	default:
+	  break;
+	}
+
+      break;
+    default:
+      break;
+    }
+
+  return success ? selectivity : DEFAULT_COMP_SELECTIVITY;
+}
+
+double
+qo_between_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  PT_NODE *and_node;
+
+  and_node = pt_expr->info.expr.arg2;
+
+  QO_ASSERT (env, and_node->node_type == PT_EXPR);
+  QO_ASSERT (env, pt_is_between_range_op (and_node->info.expr.op));
+
+  return DEFAULT_BETWEEN_SELECTIVITY;
+}
+
+double
+qo_range_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  PT_NODE *lhs, *arg1, *arg2;
+  DB_VALUE *lhs_db_value;
+  DB_VALUE *arg1_db_value;
+  DB_VALUE *arg2_db_value;
+  PRED_CLASS pc1, pc2;
+  PRED_CLASS pc_arg1, pc_arg2;
+
+  double total_selectivity;
+  double selectivity = DEFAULT_BETWEEN_SELECTIVITY;
+  int lhs_icard = 0, rhs_icard = 0, icard = 0;
+  PT_NODE *range_node;
+  PT_OP_TYPE op_type;
+
+  lhs = pt_expr->info.expr.arg1;
+
+  pc2 = qo_classify (lhs);
+
+  /* the only interesting case is 'attr RANGE {=1,=2}' or '(attr,attr) RANGE {={..},..}' */
+  if (pc2 == PC_MULTI_ATTR)
+    {
+      lhs = lhs->info.function.arg_list;
+      lhs_icard = 0;
+      for ( /* none */ ; lhs; lhs = lhs->next)
+	{
+	  /* get index cardinality */
+	  icard = qo_index_cardinality (env, lhs);
+	  if (icard <= 0)
+	    {
+	      /* the only interesting case is PT_BETWEEN_EQ_NA */
+	      icard = 1 / DEFAULT_EQUAL_SELECTIVITY;
+	    }
+	  if (lhs_icard == 0)
+	    {
+	      /* first time */
+	      lhs_icard = icard;
+	    }
+	  else
+	    {
+	      lhs_icard *= icard;
+	    }
+	}
+    }
+  else if (pc2 == PC_ATTR)
+    {
+      /* get index cardinality */
+      lhs_icard = qo_index_cardinality (env, lhs);
+    }
+  else
+    {
+      return DEFAULT_RANGE_SELECTIVITY;
+    }
+#if 1				/* unused anymore - DO NOT DELETE ME */
+  QO_ASSERT (env, !PT_EXPR_INFO_IS_FLAGED (pt_expr, PT_EXPR_INFO_FULL_RANGE));
+#endif
+
+  total_selectivity = 0.0;
+
+  for (range_node = pt_expr->info.expr.arg2; range_node; range_node = range_node->or_next)
+    {
+      QO_ASSERT (env, range_node->node_type == PT_EXPR);
+
+      op_type = range_node->info.expr.op;
+      QO_ASSERT (env, pt_is_between_range_op (op_type));
+
+      arg1 = range_node->info.expr.arg1;
+      arg2 = range_node->info.expr.arg2;
+
+      pc_arg1 = qo_classify (arg1);
+      pc1 = pc_arg1;
+
+      if (pc_arg1 == PC_HOST_VAR)
+	{
+	  arg1_db_value = &env->parser->host_variables[arg1->info.host_var.index];
+	}
+      else if (pc_arg1 == PC_CONST)
+	{
+	  arg1_db_value = &arg1->info.value.db_value;
+	}
+      else
+	{
+	  arg1_db_value = NULL;
+	}
+
+      if (arg2 != NULL)
+	{
+	  pc_arg2 = qo_classify (arg2);
+
+	  if (pc_arg2 == PC_HOST_VAR)
+	    {
+	      arg2_db_value = &env->parser->host_variables[arg2->info.host_var.index];
+	    }
+	  else if (pc_arg2 == PC_CONST)
+	    {
+	      arg2_db_value = &arg2->info.value.db_value;
+	    }
+	  else
+	    {
+	      arg2_db_value = NULL;
+	    }
+	}
+      else
+	{
+	  arg2_db_value = NULL;
+	}
+
+      if (op_type == PT_BETWEEN_GE_LE || op_type == PT_BETWEEN_GE_LT || op_type == PT_BETWEEN_GT_LE
+	  || op_type == PT_BETWEEN_GT_LT || op_type == PT_BETWEEN_INF_LT || op_type == PT_BETWEEN_INF_LE
+	  || op_type == PT_BETWEEN_GE_INF || op_type == PT_BETWEEN_GT_INF)
+	{
+	  double selectivity_a = 0.0, selectivity_b = 0.0, selectivity_backup = selectivity;
+	  bool success1 = false;
+	  bool success2 = false;
+	  bool success3 = false;
+	  switch (op_type)
+	    {
+	    case PT_BETWEEN_GE_LE:
+	      {
+		/* selectivity = sel_le(b) - sel_lt(a) */
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
+		histogram_get_comp_selectivity (lhs, arg2_db_value, false, true, &selectivity_b, &success2);
+		selectivity = selectivity_b - selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_GE_LT:
+	      {
+		/* selectivity = sel_lt(b) - sel_lt(a) */
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
+		histogram_get_comp_selectivity (lhs, arg2_db_value, false, false, &selectivity_b, &success2);
+		selectivity = selectivity_b - selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_GT_LE:
+	      {
+		/* selectivity = sel_le(b) - sel_le(a) */
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
+		histogram_get_comp_selectivity (lhs, arg2_db_value, false, true, &selectivity_b, &success2);
+		selectivity = selectivity_b - selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_GT_LT:
+	      {
+		/* selectivity = sel_lt(b) - sel_le(a) */
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
+		histogram_get_comp_selectivity (lhs, arg2_db_value, false, false, &selectivity_b, &success2);
+		selectivity = selectivity_b - selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_INF_LT:
+	      {
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, false, &selectivity_a, &success1);
+		success2 = true;
+		selectivity = selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_INF_LE:
+	      {
+		histogram_get_comp_selectivity (lhs, arg1_db_value, false, true, &selectivity_a, &success1);
+		success2 = true;
+		selectivity = selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_GT_INF:
+	      {
+		histogram_get_comp_selectivity (lhs, arg1_db_value, true, false, &selectivity_a, &success1);
+		success2 = true;
+		selectivity = selectivity_a;
+		break;
+	      }
+	    case PT_BETWEEN_GE_INF:
+	      {
+		histogram_get_comp_selectivity (lhs, arg1_db_value, true, true, &selectivity_a, &success1);
+		success2 = true;
+		selectivity = selectivity_a;
+		break;
+	      }
+	    default:
+	      break;
+	    }
+
+	  double default_zero_selectivity = 0.0;
+	  histogram_get_default_selectivity (lhs, arg1_db_value, &default_zero_selectivity, &success3);
+
+	  if (success3)
+	    {
+	      selectivity = MAX (selectivity, default_zero_selectivity);
+	    }
+
+	  if (!(success1 && success2))
+	    {
+	      if (op_type == PT_BETWEEN_INF_LT || op_type == PT_BETWEEN_INF_LE || op_type == PT_BETWEEN_GE_INF
+		  || op_type == PT_BETWEEN_GT_INF)
+		{
+		  selectivity = DEFAULT_COMP_SELECTIVITY;
+		}
+	      else
+		{
+		  selectivity = DEFAULT_BETWEEN_SELECTIVITY;
+		}
+	    }
+	}
+      else if (op_type == PT_BETWEEN_EQ_NA)
+	{
+	  /* PT_BETWEEN_EQ_NA have only one argument */
+
+	  selectivity = DEFAULT_EQUAL_SELECTIVITY;
+
+	  if (pc1 == PC_ATTR)
+	    {
+	      /* attr1 range (attr2 = ) */
+	      rhs_icard = qo_index_cardinality (env, arg1);
+
+	      icard = MAX (lhs_icard, rhs_icard);
+	      if (icard != 0)
+		{
+		  selectivity = (1.0 / icard);
+		}
+	      else
+		{
+		  selectivity = DEFAULT_EQUIJOIN_SELECTIVITY;
+		}
+	    }
+	  else
+	    {
+	      bool success = false;
+
+	      histogram_get_equal_selectivity (lhs, arg1_db_value, &selectivity, &success);
+
+	      if (!success)
+		{
+		  /* attr1 range (const = ) */
+		  if (lhs_icard != 0)
+		    {
+		      selectivity = (1.0 / lhs_icard);
+		    }
+		  else
+		    {
+		      selectivity = DEFAULT_EQUAL_SELECTIVITY;
+		    }
+		}
+	    }
+	}
+
+
+      selectivity = MAX (selectivity, 0.0);
+      selectivity = MIN (selectivity, 1.0);
+
+      total_selectivity = qo_or_selectivity (env, total_selectivity, selectivity);
+      total_selectivity = MAX (total_selectivity, 0.0);
+      total_selectivity = MIN (total_selectivity, 1.0);
+    }
+
+  return total_selectivity;
+}
+
+double
+qo_all_some_in_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  PRED_CLASS pc_lhs, pc_rhs;
+  double list_card = 0.0, icard = 0.0;
+  double equal_selectivity = 1.0;
+  PT_NODE *lhs;
+  PT_NODE *arg1, *arg2;
+
+  /* To avoid repeated dereferencing */
+  arg1 = pt_expr->info.expr.arg1;
+  arg2 = pt_expr->info.expr.arg2;
+
+  /* determine the class of each side of the range */
+  pc_lhs = qo_classify (arg1);
+  pc_rhs = qo_classify (arg2);
+
+  /* The only interesting cases are: attr IN set or (attr,attr) IN set or attr IN subquery */
+  if ((pc_lhs == PC_MULTI_ATTR || pc_lhs == PC_ATTR) && (pc_rhs == PC_SET || pc_rhs == PC_SUBQUERY))
+    {
+      if (pc_lhs == PC_MULTI_ATTR)
+	{
+	  for (lhs = arg1->info.function.arg_list; lhs; lhs = lhs->next)
+	    {
+	      /* get index cardinality */
+	      icard = qo_index_cardinality (env, lhs);
+	      if (icard > 0.0)
+		{
+		  equal_selectivity *= (1.0 / icard);
+		}
+	      else
+		{
+		  /* If no index, multiply by default selectivity for each attribute */
+		  equal_selectivity *= DEFAULT_EQUAL_SELECTIVITY;
+		}
+	    }
+	}
+      else if (pc_lhs == PC_ATTR)
+	{
+	  /* check for index on the attribute.  */
+	  icard = qo_index_cardinality (env, arg1);
+	  if (icard > 0.0)
+	    {
+	      equal_selectivity *= (1.0 / icard);
+	    }
+	  else
+	    {
+	      equal_selectivity = DEFAULT_EQUAL_SELECTIVITY;
+	    }
+	}
+
+      /* determine cardinality of set or subquery */
+      if (pc_rhs == PC_SET)
+	{
+	  if (pt_is_function (arg2))
+	    {
+	      list_card = pt_length_of_list (arg2->info.function.arg_list);
+	    }
+	  else
+	    {
+	      list_card = pt_length_of_list (arg2->info.value.data_value.set);
+	    }
+	}
+      else if (pc_rhs == PC_SUBQUERY)
+	{
+	  if (arg2->info.query.xasl)
+	    {
+	      list_card = ((XASL_NODE *) arg2->info.query.xasl)->cardinality;
+	    }
+	  else
+	    {
+	      /* legacy default list_card is 1000. Maybe it won't come in here */
+	      list_card = 1000.0;
+	    }
+	}
+
+      /* compute selectivity--cap at 0.5 */
+      double in_selectivity = list_card * equal_selectivity;
+      return in_selectivity > 0.5 ? 0.5 : in_selectivity;
+    }
+
+  return DEFAULT_IN_SELECTIVITY;
+}
+
+PRED_CLASS
+qo_classify (PT_NODE * attr)
+{
+  switch (attr->node_type)
+    {
+    case PT_NAME:
+    case PT_DOT_:
+      return PC_ATTR;
+
+    case PT_VALUE:
+      if (PT_IS_SET_TYPE (attr))
+	{
+	  return PC_SET;
+	}
+      else if (attr->type_enum == PT_TYPE_NULL)
+	{
+	  return PC_OTHER;
+	}
+      else
+	{
+	  return PC_CONST;
+	}
+
+    case PT_HOST_VAR:
+      return PC_HOST_VAR;
+
+    case PT_SELECT:
+    case PT_UNION:
+    case PT_INTERSECTION:
+    case PT_DIFFERENCE:
+      return PC_SUBQUERY;
+
+    case PT_FUNCTION:
+      /* (attr,attr) or (?,?) */
+      if (PT_IS_SET_TYPE (attr))
+	{
+	  PT_NODE *func_arg;
+	  func_arg = attr->info.function.arg_list;
+	  for ( /* none */ ; func_arg; func_arg = func_arg->next)
+	    {
+	      if (func_arg->node_type == PT_NAME)
+		{
+		  /* none */
+		}
+	      else if (func_arg->node_type == PT_HOST_VAR)
+		{
+		  return PC_SET;
+		}
+	      else
+		{
+		  return PC_OTHER;
+		}
+	    }
+	  return PC_MULTI_ATTR;
+	}
+      else
+	{
+	  return PC_OTHER;
+	}
+
+    case PT_EXPR:
+      if (pt_is_function_index_expression (attr))
+	{
+	  return PC_ATTR;
+	}
+      [[fallthrough]];
+    default:
+      return PC_OTHER;
+    }
+}
+
+double
+qo_like_selectivity (QO_ENV * env, PT_NODE * pt_expr)
+{
+  /* Base LIKE selectivity: the system parameter PRM_ID_LIKE_TERM_SELECTIVITY.
+   * Histogram/pattern-based LIKE selectivity is added in the LIKE-selectivity layer (PR L2). */
+  PT_NODE *lhs = pt_expr->info.expr.arg1;
+  PT_NODE *rhs = pt_expr->info.expr.arg2;
+
+  if (lhs == NULL || rhs == NULL)
+    {
+      return 0.0;
+    }
+
+  return (double) prm_get_float_value (PRM_ID_LIKE_TERM_SELECTIVITY);
+}

--- a/src/query/execute_statement.c
+++ b/src/query/execute_statement.c
@@ -12257,6 +12257,7 @@ error_return:
   return error;
 }
 
+
 /*
  * do_create_midxkey_for_constraint () - create a MIDX_KEY db_value for the
  *					 specified constraint using the values


### PR DESCRIPTION
Draft (demo/review). Built on `feature/reservoir-sampling`.

**Adds vs reservoir-sampling (4 commits):**
- **L1** — histogram-based equality/range/MCV/NULL selectivity + planner wiring (`query_planner_selectivity.c`).
- **L2** — histogram LIKE/pattern selectivity (MCV-list aware + confidence-weighted non-MCV blend).
- **eqjoin fix** — `histogram_get_eqjoin_selectivity` reads the MCV list (not buckets): reservoir v2 stores MCVs separately, so the old bucket-read gave join selectivity 0 for all-MCV columns (e.g. role_type.id). Floored at 1/max(NDV).
- **iscan NDV** — `qo_iscan_cost` uses reservoir column NDV (`QO_SEG_INFO->ndv`) for the leading index column instead of the sampled B+tree key count (JOB 29a: role_id stored NDV 587K vs actual 11).

JOB: large execution-time gains; remaining plan-time items under investigation.